### PR TITLE
Processing find and exists endpoints

### DIFF
--- a/app/controllers/processings_controller.rb
+++ b/app/controllers/processings_controller.rb
@@ -15,4 +15,32 @@ class ProcessingsController < ApplicationController
       format.json { render json: {error_message: error_message} }
     end
   end
+
+  def show
+    if set_processing
+      respond_with_json({processing: @processing})
+    end
+  end
+
+  def exists
+    respond_with_json({exists: Processing.exists?(params[:id].to_i)})
+  end
+
+  private
+
+  def set_processing
+    begin
+      @processing = Processing.find(params[:id].to_i)
+      true
+    rescue ActiveRecord::RecordNotFound => exception
+      respond_with_json({errors: [exception.message]}, :unprocessable_entity)
+      false
+    end
+  end
+
+  def respond_with_json(json, status=:ok)
+    respond_to do |format|
+      format.json { render json: json, status: status }
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,8 @@ Rails.application.routes.draw do
 
   get 'processings/:id/process_times' => 'processings#process_times'
   get 'processings/:id/error_message' => 'processings#error_message'
+  get 'processings/:id' => 'processings#show'
+  get 'processings/:id/exists' => 'processings#exists'
 
   resources :process_times, only: [:index, :show]
   get 'process_times/:id/processing' => 'process_times#processing'

--- a/spec/controllers/processings_controller_spec.rb
+++ b/spec/controllers/processings_controller_spec.rb
@@ -30,7 +30,65 @@ RSpec.describe ProcessingsController, :type => :controller do
     it 'is expected to return the error message converted to JSON' do
       expect(JSON.parse(response.body)).to eq(JSON.parse({error_message: processing_with_error.error_message}.to_json))
     end
+  end
 
+  describe 'show' do
+    context 'when the Processing exists' do
+      before :each do
+        Processing.expects(:find).with(processing.id).returns(processing)
 
+        get :show, id: processing.id, format: :json
+      end
+
+      it { is_expected.to respond_with(:success) }
+
+      it 'is expected to return the list of repositories converted to JSON' do
+        expect(JSON.parse(response.body)).to eq(JSON.parse({processing: processing}.to_json))
+      end
+    end
+
+    context 'when the Processing exists' do
+      before :each do
+        Processing.expects(:find).with(processing.id).raises(ActiveRecord::RecordNotFound)
+
+        get :show, id: processing.id, format: :json
+      end
+
+      it { is_expected.to respond_with(:unprocessable_entity) }
+
+      it 'should return the error description' do
+        expect(JSON.parse(response.body)).to eq(JSON.parse({errors: ['ActiveRecord::RecordNotFound']}.to_json))
+      end
+    end
+  end
+
+  describe 'exists' do
+    context 'when the processing exists' do
+      before :each do
+        Processing.expects(:exists?).with(processing.id).returns(true)
+
+        get :exists, id: processing.id, format: :json
+      end
+
+      it { is_expected.to respond_with(:success) }
+
+      it 'should return true' do
+        expect(JSON.parse(response.body)).to eq(JSON.parse({exists: true}.to_json))
+      end
+    end
+
+    context 'when the processing does not exist' do
+      before :each do
+        Processing.expects(:exists?).with(processing.id).returns(false)
+
+        get :exists, id: processing.id, format: :json
+      end
+
+      it { is_expected.to respond_with(:success) }
+
+      it 'should return false' do
+        expect(JSON.parse(response.body)).to eq(JSON.parse({exists: false}.to_json))
+      end
+    end
   end
 end

--- a/spec/routing/processings_routing_spec.rb
+++ b/spec/routing/processings_routing_spec.rb
@@ -6,5 +6,9 @@ describe ProcessingsController, :type => :routing do
                   to(controller: :processings, action: :process_times, id: 1) }
     it { is_expected.to route(:get, '/processings/1/error_message').
                   to(controller: :processings, action: :error_message, id: 1) }
+    it { is_expected.to route(:get, '/processings/1').
+                  to(controller: :processings, action: :show, id: 1) }
+    it { is_expected.to route(:get, '/processings/1/exists').
+                  to(controller: :processings, action: :exists, id: 1) }
   end
 end


### PR DESCRIPTION
This is necessary for better working of ModuleResult method processing on kalibro_client

Which is a requirement for the metric_history method.