### PR TITLE
MetricCollector details listing is cached

### DIFF
--- a/lib/metric_collector/native.rb
+++ b/lib/metric_collector/native.rb
@@ -11,14 +11,14 @@ module MetricCollector
 
     def self.details
       # This cache will represent a HUGE improvement for MetricCollectorsController response times
-      Rails.cache.fetch("metric_collector/details", expires_in: 10.minutes) do
+      Rails.cache.fetch("metric_collector/details", expires_in: 1.day) do
         @details = []
 
         available.each do |name, collector|
           collector_instance = collector.new
           @details << MetricCollector::Details.new(name: name,
-                                                  description: collector_instance.details.description,
-                                                  supported_metrics: collector_instance.details.supported_metrics)
+                                                   description: collector_instance.details.description,
+                                                   supported_metrics: collector_instance.details.supported_metrics)
         end
       end
 

--- a/lib/metric_collector/native.rb
+++ b/lib/metric_collector/native.rb
@@ -10,16 +10,19 @@ module MetricCollector
     end
 
     def self.details
-      details = []
+      # This cache will represent a HUGE improvement for MetricCollectorsController response times
+      Rails.cache.fetch("metric_collector/details", expires_in: 10.minutes) do
+        @details = []
 
-      available.each do |name, collector|
-        collector_instance = collector.new
-        details << MetricCollector::Details.new(name: name,
-                                                description: collector_instance.details.description,
-                                                supported_metrics: collector_instance.details.supported_metrics)
+        available.each do |name, collector|
+          collector_instance = collector.new
+          @details << MetricCollector::Details.new(name: name,
+                                                  description: collector_instance.details.description,
+                                                  supported_metrics: collector_instance.details.supported_metrics)
+        end
       end
 
-      return details
+      return @details
     end
   end
 end

--- a/spec/lib/metric_collector/native_spec.rb
+++ b/spec/lib/metric_collector/native_spec.rb
@@ -45,6 +45,10 @@ describe MetricCollector::Native do
           expect(collector.supported_metrics.first.code).to eq(metric_collector.details.supported_metrics.first.code)
         end
       end
+
+      after :each do
+        Rails.cache.clear
+      end
     end
   end
 end


### PR DESCRIPTION
This may improve the response times for metric listing. Specially
Prezento's MetricConfiguration creation process.

kalibro_client performance improved from:

Performance::MetricCollectorDetailsFindByCode
    ----------
    * Process Time: 0.016660789400000087
    * Wall Time: 5.652877998352051

To:

Performance::MetricCollectorDetailsFindByCode
----------
* Process Time: 0.01192529619999998
* Wall Time: 0.04177765846252442