### PR TITLE
Adds a default value to repository branch.

### DIFF
--- a/db/migrate/20150613123922_add_default_value_to_repository_branch.rb
+++ b/db/migrate/20150613123922_add_default_value_to_repository_branch.rb
@@ -1,0 +1,9 @@
+class AddDefaultValueToRepositoryBranch < ActiveRecord::Migration
+  def up
+    change_column :repositories, :branch, :string, null: false, default: 'master'
+  end
+
+  def down
+    change_column :repositories, :branch, :string, null: true, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,21 +11,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150527165919) do
+ActiveRecord::Schema.define(version: 20150613123922) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "delayed_jobs", force: :cascade do |t|
-    t.integer  "priority",   default: 0, null: false
-    t.integer  "attempts",   default: 0, null: false
-    t.text     "handler",                null: false
+    t.integer  "priority",               default: 0, null: false
+    t.integer  "attempts",               default: 0, null: false
+    t.text     "handler",                            null: false
     t.text     "last_error"
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"
-    t.string   "locked_by"
-    t.string   "queue"
+    t.string   "locked_by",  limit: 255
+    t.string   "queue",      limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -33,8 +33,8 @@ ActiveRecord::Schema.define(version: 20150527165919) do
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
   create_table "kalibro_modules", force: :cascade do |t|
-    t.string   "long_name"
-    t.string   "granlrty"
+    t.string   "long_name",        limit: 255
+    t.string   "granlrty",         limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "module_result_id"
@@ -59,7 +59,7 @@ ActiveRecord::Schema.define(version: 20150527165919) do
   add_index "module_results", ["parent_id"], name: "index_module_results_on_parent_id", using: :btree
 
   create_table "process_times", force: :cascade do |t|
-    t.string   "state"
+    t.string   "state",         limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "processing_id"
@@ -67,7 +67,7 @@ ActiveRecord::Schema.define(version: 20150527165919) do
   end
 
   create_table "processings", force: :cascade do |t|
-    t.string   "state"
+    t.string   "state",                 limit: 255
     t.integer  "repository_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -76,25 +76,25 @@ ActiveRecord::Schema.define(version: 20150527165919) do
   end
 
   create_table "projects", force: :cascade do |t|
-    t.string   "name"
-    t.string   "description"
+    t.string   "name",        limit: 255
+    t.string   "description", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   create_table "repositories", force: :cascade do |t|
-    t.string   "name"
-    t.string   "scm_type"
-    t.string   "address"
-    t.string   "description",              default: ""
-    t.string   "license",                  default: ""
-    t.integer  "period",                   default: 0
+    t.string   "name",                     limit: 255
+    t.string   "scm_type",                 limit: 255
+    t.string   "address",                  limit: 255
+    t.string   "description",              limit: 255, default: ""
+    t.string   "license",                  limit: 255, default: ""
+    t.integer  "period",                               default: 0
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "kalibro_configuration_id"
     t.integer  "project_id"
-    t.string   "code_directory"
-    t.string   "branch"
+    t.string   "code_directory",           limit: 255
+    t.string   "branch",                               default: "master", null: false
   end
 
 end


### PR DESCRIPTION
Just adding the branch column would make already existing repositorys to remain
with a NULL branch which will then break their processing.

Adding master as the default branch is a workaround since master may not be the
default branch for such repositories. As well adding a not null restriction
will enforce that the database add the default value to already existing
entries.

This is a critical bugfix for mezuro.org that should generate a new version ASAP.