### PR TITLE
Added a call to destroy the previous process times on preparer

### DIFF
--- a/lib/processor/preparer.rb
+++ b/lib/processor/preparer.rb
@@ -4,6 +4,10 @@ module Processor
     protected
 
     def self.task(context)
+      # Make sure no pre-existing processing times exist. This ensure a failed
+      # processing does not leave leftovers.
+      context.processing.process_times.destroy_all
+
       context.repository.update(code_directory: generate_dir_name)
       metrics_list(context)
     end

--- a/spec/factories/process_times.rb
+++ b/spec/factories/process_times.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :process_time do
-    id 100
+    sequence(:id, 1)
     state "MyString"
     created_at "2014-07-31T08:58:07+00:00"
     updated_at "2014-07-31T09:12:01+00:00"

--- a/spec/factories/processings.rb
+++ b/spec/factories/processings.rb
@@ -1,13 +1,12 @@
 FactoryGirl.define do
   factory :processing do
-    id "31"
     created_at "2011-10-20T18:26:43.151+00:00"
     updated_at "2011-10-20T18:26:43.151+00:00"
     state "READY"
-    process_times {[FactoryGirl.build(:process_time)]}
     root_module_result_id 13
-    repository { FactoryGirl.build(:repository) }
     module_results { [] }
+
+    association :repository, factory: :repository, strategy: :build
 
     trait :error do
       error_message "ERROR message"

--- a/spec/lib/processor/preparer_spec.rb
+++ b/spec/lib/processor/preparer_spec.rb
@@ -6,13 +6,17 @@ describe Processor::Preparer do
     let!(:code_dir) { "/tmp/test" }
     let!(:kalibro_configuration) { FactoryGirl.build(:kalibro_configuration) }
     let!(:repository) { FactoryGirl.build(:repository, scm_type: "GIT", kalibro_configuration: kalibro_configuration) }
-    let!(:processing) { FactoryGirl.build(:processing, repository: repository) }
+    let!(:processing) { FactoryGirl.build(:processing, repository: repository, process_times: FactoryGirl.build_stubbed_list(:process_time, 1)) }
     let!(:context) { FactoryGirl.build(:context, repository: repository, processing: processing) }
     let!(:metric_configuration) { FactoryGirl.build(:metric_configuration, metric: FactoryGirl.build(:analizo_native_metric)) }
     let!(:compound_metric_configuration) { FactoryGirl.build(:compound_metric_configuration) }
     let!(:dir) { YAML.load_file("#{Rails.root}/config/repositories.yml")["repositories"]["path"] }
 
     describe 'task' do
+      before :each do
+        processing.process_times.expects(:destroy_all).once
+      end
+
       context 'when the base directory exists' do
         before :each do
           repository.expects(:update).with(code_directory: code_dir)


### PR DESCRIPTION
Also refactored the processing factory to ensure that the process times
are created on each test that actually needs them. Additionally, stubbed
the process times on the preparer unit test to ensure that the call to
destroy_all is being made on the stubbed process time list, instead of
a call on an actual active record association.

Signed-off-by: Daniel Miranda <danielkza2@gmail.com>