### PR TITLE
Changed name validation on repository from project to a global scope

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -5,8 +5,7 @@ class Repository < ActiveRecord::Base
   has_many :processings, dependent: :destroy
 
   validates :name, presence: true
-  validates :name, uniqueness: { scope: :project_id ,
-    message: "should be unique within project" }
+  validates :name, uniqueness: true
   validates :address, presence: true
   validates :kalibro_configuration_id, presence: true
 

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -6,7 +6,7 @@ describe Repository, :type => :model do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:address) }
     it { is_expected.to validate_presence_of(:kalibro_configuration_id) }
-    it { is_expected.to validate_uniqueness_of(:name).scoped_to(:project_id).with_message(/should be unique within project/) }
+    it { is_expected.to validate_uniqueness_of(:name) }
   end
 
   describe 'associations' do


### PR DESCRIPTION
With the decoupled repositories, it is possible to create them without a
project, negating the previous scope relevancy. Now a repository needs a
globally unique name to be created.

Signed-off-by: Pedro Scocco <pedroscocco@gmail.com>
Signed off by: Diego Araújo <diegoamc90@gmail.com>