### PR TITLE
Fixes the calculation of metrics with SOFTWARE scope

### DIFF
--- a/features/runner.feature
+++ b/features/runner.feature
@@ -39,7 +39,7 @@ Feature: Runner run
     When I run for the given repository
     Then I should receive a processing error
 
-  @clear_repository @kalibro_configuration_restart @wip
+  @clear_repository @kalibro_configuration_restart
   Scenario: Aggregating some metric values
     Given I have sample readings
     And I have a sample kalibro configuration

--- a/features/step_definitions/runner_steps.rb
+++ b/features/step_definitions/runner_steps.rb
@@ -220,5 +220,5 @@ end
 
 
 Then(/^the Root ModuleResult retrieved should have exactly "(.*?)" MetricResults$/) do |count|
-  expect(@processing.root_module_result.metric_results.count).to be_eq(count.to_i)
+  expect(@processing.root_module_result.metric_results.count).to eq(count.to_i)
 end

--- a/lib/metric_collector/native/analizo/parser.rb
+++ b/lib/metric_collector/native/analizo/parser.rb
@@ -52,7 +52,7 @@ module MetricCollector
 
         def parse(result_map)
           if result_map['_filename'].nil?
-            module_result = module_result("", KalibroClient::Entities::Miscellaneous::Granularity::SOFTWARE)
+            module_result = module_result("ROOT", KalibroClient::Entities::Miscellaneous::Granularity::SOFTWARE)
           else
             module_result = module_result(module_name(result_map['_filename'].last, result_map['_module']), KalibroClient::Entities::Miscellaneous::Granularity::CLASS)
           end

--- a/spec/lib/metric_collector/native/analizo/parser_spec.rb
+++ b/spec/lib/metric_collector/native/analizo/parser_spec.rb
@@ -19,7 +19,7 @@ describe MetricCollector::Native::Analizo::Parser, :type => :model do
 
       it 'is expected to parse the raw results into ModuleResults and TreeMetricResults' do
         YAML.expects(:load_documents).with(analizo_metric_collector_list.raw_result).returns(analizo_metric_collector_list.parsed_result)
-        KalibroModule.expects(:new).with(long_name: "", granularity: KalibroClient::Entities::Miscellaneous::Granularity::SOFTWARE).returns(root_kalibro_module)
+        KalibroModule.expects(:new).with(long_name: "ROOT", granularity: KalibroClient::Entities::Miscellaneous::Granularity::SOFTWARE).returns(root_kalibro_module)
         KalibroModule.expects(:new).with(long_name: "Class.Module", granularity: KalibroClient::Entities::Miscellaneous::Granularity::CLASS).returns(class_kalibro_module)
         ModuleResult.expects(:find_by_module_and_processing).with(root_kalibro_module, processing).returns(nil)
         ModuleResult.expects(:find_by_module_and_processing).with(class_kalibro_module, processing).returns(module_result)


### PR DESCRIPTION
Analizo created a module result with SOFTWARE scope and named with an
empty string. The TreeBuilder state tries to create a root module result
with name "ROOT", if it can't find it on the database.
That, along with the aggregation of two metric results with SOFTWARE granularities, was
leading to inconsistencies that made Kalibro lose information about
results of analizo metrics with SOFTWARE scope.

Now, the analizo parser tries to create a new module result already with
name "ROOT". It avoids the creation of new root module results and
prevents the aggregation of two metric results with SOFTWARE
granularities (which does not make sense, anyway).

Signed off by: Daniel Miranda <danielkza2@gmail.com>