### PR TITLE
Fixed use of instance variable in TreeBuilder processing step

### DIFF
--- a/lib/processor/tree_builder.rb
+++ b/lib/processor/tree_builder.rb
@@ -1,20 +1,19 @@
 module Processor
   class TreeBuilder < ProcessingStep
-
     # Number not to small and not too large. If someday there is the need, this may be a configuration
     BATCH_SIZE = 100
 
     protected
 
     def self.task(runner)
-      @offset = 0
-      module_results = module_result_batch(runner.processing)
+      offset = 0
+      module_results = module_result_batch(runner.processing, offset)
       while !module_results.empty?
         module_results.each do |module_result|
           set_parent(module_result, module_results, runner.processing)
         end
-        @offset += BATCH_SIZE
-        module_results = module_result_batch(runner.processing)
+        offset += BATCH_SIZE
+        module_results = module_result_batch(runner.processing, offset)
       end
     end
 
@@ -24,8 +23,8 @@ module Processor
 
     private
 
-    def self.module_result_batch(processing)
-      ModuleResult.where(processing: processing).limit(BATCH_SIZE).offset(@offset)
+    def self.module_result_batch(processing, offset)
+      ModuleResult.where(processing: processing).limit(BATCH_SIZE).offset(offset)
     end
 
     def self.set_parent(module_result, module_results, processing)


### PR DESCRIPTION
It can't happen since all the methods are class methods. It would cause
conflicts if multiple processings happened at the same time.