### PR TITLE
Rename KalibroModule granlrty to granularity

### DIFF
--- a/app/models/kalibro_module.rb
+++ b/app/models/kalibro_module.rb
@@ -27,11 +27,11 @@ class KalibroModule < ActiveRecord::Base
   end
 
   def granularity=(value)
-    self.granlrty = value.to_s
+    super(value.to_s)
   end
 
   def granularity
-    KalibroClient::Entities::Miscellaneous::Granularity.new(self.granlrty.to_sym)
+    KalibroClient::Entities::Miscellaneous::Granularity.new(super.to_sym)
   end
 
   def to_s

--- a/app/models/module_result.rb
+++ b/app/models/module_result.rb
@@ -13,7 +13,7 @@ class ModuleResult < ActiveRecord::Base
     ModuleResult.joins(:kalibro_module).
       where(processing: processing).
       where("kalibro_modules.long_name" => kalibro_module.long_name).
-      where("kalibro_modules.granlrty" => kalibro_module.granularity.to_s).first
+      where("kalibro_modules.granularity" => kalibro_module.granularity.to_s).first
   end
 
   def metric_result_for(metric)

--- a/db/migrate/20151002172231_rename_kalibro_module_granlrty_to_granularity.rb
+++ b/db/migrate/20151002172231_rename_kalibro_module_granlrty_to_granularity.rb
@@ -1,0 +1,5 @@
+class RenameKalibroModuleGranlrtyToGranularity < ActiveRecord::Migration
+  def change
+    rename_column :kalibro_modules, :granlrty, :granularity
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150909210112) do
+ActiveRecord::Schema.define(version: 20151002172231) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 20150909210112) do
 
   create_table "kalibro_modules", force: :cascade do |t|
     t.string   "long_name",        limit: 255
-    t.string   "granlrty",         limit: 255
+    t.string   "granularity",      limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "module_result_id"

--- a/spec/models/kalibro_module_spec.rb
+++ b/spec/models/kalibro_module_spec.rb
@@ -2,6 +2,19 @@ require 'rails_helper'
 
 describe KalibroModule, :type => :model do
 
+=begin
+  describe 'initialize' do
+    let(:long_name) { 'app.model.kalibro_module' }
+    let(:granularity) { 'CLASS' }
+
+    it 'is expected to set long_name and granularity' do
+      subject = KalibroModule.new(long_name: long_name, granularity: granularity)
+
+      expect(subject.long_name).to eq(long_name)
+      expect(subject.granularity).to eq(KalibroClient::Entities::Miscellaneous::Granularity.new(granularity.to_sym))
+    end
+  end
+=end
   describe 'associations' do
     it { is_expected.to belong_to(:module_result) }
   end
@@ -70,6 +83,27 @@ describe KalibroModule, :type => :model do
             expect(parent.name).to eq(['pre_name'])
           end
         end
+      end
+    end
+
+    describe 'granularity=' do
+
+      subject { FactoryGirl.build( :kalibro_module ) }
+
+      it "is expected to convert the value to string" do
+        granularity = mock("granularity")
+        granularity.expects(:to_s).returns("CLASS")
+
+        subject.granularity = granularity
+      end
+    end
+
+    describe 'granularity' do
+
+      subject { FactoryGirl.build( :kalibro_module ) }
+
+      it 'is expected to return a KalibroClient::Entities::Miscellaneous::Granularity instance' do
+        expect(subject.granularity).to be_a(KalibroClient::Entities::Miscellaneous::Granularity)
       end
     end
   end

--- a/spec/models/kalibro_module_spec.rb
+++ b/spec/models/kalibro_module_spec.rb
@@ -1,20 +1,6 @@
 require 'rails_helper'
 
 describe KalibroModule, :type => :model do
-
-=begin
-  describe 'initialize' do
-    let(:long_name) { 'app.model.kalibro_module' }
-    let(:granularity) { 'CLASS' }
-
-    it 'is expected to set long_name and granularity' do
-      subject = KalibroModule.new(long_name: long_name, granularity: granularity)
-
-      expect(subject.long_name).to eq(long_name)
-      expect(subject.granularity).to eq(KalibroClient::Entities::Miscellaneous::Granularity.new(granularity.to_sym))
-    end
-  end
-=end
   describe 'associations' do
     it { is_expected.to belong_to(:module_result) }
   end

--- a/spec/models/module_result_spec.rb
+++ b/spec/models/module_result_spec.rb
@@ -75,7 +75,7 @@ describe ModuleResult, :type => :model do
       before :each do
         name_filtered_results = Object.new
         name_filtered_results.expects(:where).
-          with("kalibro_modules.granlrty" => kalibro_module.granularity.to_s).
+          with("kalibro_modules.granularity" => kalibro_module.granularity.to_s).
           returns([module_result])
 
         processing_filtered_results = Object.new


### PR DESCRIPTION
We were using granlrty to avoid conflicts with Java implementation
of Kalibro.

After renaming, we have found out that overriding ActiveRecord
attributes may lead to errors on the database persistance. For more
information, see:

http://api.rubyonrails.org/classes/ActiveRecord/Base.html#class-ActiveRecord%3a%3aBase-label-Overwriting+default+accessors

As well, unit tests were missing for the getter and setter. They
were created.

Signed off by: Rafael Reggiani Manzo <rr.manzo@gmail.com>

This closes https://github.com/mezuro/kalibro_processor/issues/97