### PR TITLE
Add metric type for supported listing

### DIFF
--- a/lib/metric_collector/base.rb
+++ b/lib/metric_collector/base.rb
@@ -20,6 +20,18 @@ module MetricCollector
 
     def self.available?; raise NotImplementedError; end
 
+    def parse_supported_metrics(metrics_path, metric_collector_name, languages)
+      supported_metrics = {}
+      YAML.load_file(metrics_path)[:metrics].each do | key, value |
+        if value[:type] == "NativeMetricSnapshot"
+          supported_metrics[key] = KalibroClient::Entities::Miscellaneous::NativeMetric.new(value[:name], key, value[:scope], languages, metric_collector_name)
+        else
+          supported_metrics[key] = KalibroClient::Entities::Miscellaneous::HotspotMetric.new(value[:name], key, languages, metric_collector_name)
+        end
+      end
+      supported_metrics
+    end
+
     protected
 
     def processing=(processing)

--- a/lib/metric_collector/native/metric_fu/collector.rb
+++ b/lib/metric_collector/native/metric_fu/collector.rb
@@ -20,11 +20,7 @@ module MetricCollector
         end
 
         def parse_supported_metrics
-          supported_metrics = {}
-          YAML.load_file("#{Rails.root}/lib/metric_collector/native/metric_fu/metrics.yml")[:metrics].each do | key, value |
-            supported_metrics[key] = KalibroClient::Entities::Miscellaneous::NativeMetric.new(value[:name], key, value[:scope], [:RUBY], "MetricFu")
-          end
-          supported_metrics
+          super("#{Rails.root}/lib/metric_collector/native/metric_fu/metrics.yml", "MetricFu", [:RUBY])
         end
 
         def self.available?

--- a/lib/metric_collector/native/metric_fu/metrics.yml
+++ b/lib/metric_collector/native/metric_fu/metrics.yml
@@ -13,13 +13,15 @@
     :name: Pain
     :description: Measures how hard (painful) it is to test the code
     :scope: METHOD
+    :type: NativeMetricSnapshot
 
   :saikuro:
     :name: Cyclomatic Complexity
     :description: Cyclomatic complexity is a graphical measurement of the number of possible paths through the normal flow of a program
     :scope: METHOD
+    :type: NativeMetricSnapshot
 
   :flay:
     :name: Duplicate Code
     :description: 'Flay analyzes code for structural similarities. Differences in literal values, variable, class, method names, whitespace, programming style, braces vs do/end, etc are all ignored'
-    :scope: PACKAGE
+    :type: HotspotMetricSnapshot

--- a/lib/metric_collector/native/metric_fu/parser.rb
+++ b/lib/metric_collector/native/metric_fu/parser.rb
@@ -15,13 +15,13 @@ module MetricCollector
           parsed_result = YAML.load_file(yaml_file_path)
 
           wanted_metric_configurations.each do |metric_configuration|
-            code = metric_configuration.metric.code
+            code = metric_configuration.metric.code.to_s
             @parsers[code].parse(parsed_result[code.to_sym], processing, metric_configuration)
           end
         end
 
         def self.default_value_from(metric_code)
-          @parsers[metric_code].default_value
+          @parsers[metric_code.to_s].default_value
         end
       end
     end

--- a/lib/metric_collector/native/radon/collector.rb
+++ b/lib/metric_collector/native/radon/collector.rb
@@ -24,11 +24,7 @@ module MetricCollector
         end
 
         def parse_supported_metrics
-          supported_metrics = {}
-          YAML.load_file("#{Rails.root}/lib/metric_collector/native/radon/metrics.yml")[:metrics].each do | code, details |
-            supported_metrics[code] = KalibroClient::Entities::Miscellaneous::NativeMetric.new(details[:name], code, details[:scope], [:PYTHON], "Radon")
-          end
-          supported_metrics
+          super("#{Rails.root}/lib/metric_collector/native/radon/metrics.yml", "Radon", [:PYTHON])
         end
       end
     end

--- a/lib/metric_collector/native/radon/metrics.yml
+++ b/lib/metric_collector/native/radon/metrics.yml
@@ -4,39 +4,47 @@
     :name: Cyclomatic Complexity
     :description: Cyclomatic complexity is a quantitative measure of the number of linearly independent paths through a program's source code.
     :scope: METHOD
+    :type: NativeMetricSnapshot
 
   :mi:
     :name: Maintainability Index
     :description: Measures how easy it is to maintain the code.
     :scope: PACKAGE
+    :type: NativeMetricSnapshot
 
   :loc:
     :name: Lines of code
     :description: The total number of lines of code.
     :scope: PACKAGE
+    :type: NativeMetricSnapshot
 
   :lloc:
     :name: Logical Lines of code
     :description: The number of logical lines of code. Every logical line of code contains exactly one statement.
     :scope: PACKAGE
+    :type: NativeMetricSnapshot
 
   :sloc:
     :name: Source Lines of code
     :description: The number of source lines of code not necessarily corresponding to the logical one.
     :scope: PACKAGE
+    :type: NativeMetricSnapshot
 
   :comments:
     :name: Number of comment lines
     :description: The number of comment lines. Multiline strings are not counted as comment since to the Python interpreters they are just strings.
     :scope: PACKAGE
+    :type: NativeMetricSnapshot
 
   :multi:
     :name: Multi-line strings
     :description: The number of lines which represent multi-line strings.
     :scope: PACKAGE
+    :type: NativeMetricSnapshot
 
   :blank:
     :name: Number of blank lines
     :description: The number of blank lines containing just white spaces.
     :scope: PACKAGE
+    :type: NativeMetricSnapshot
 

--- a/spec/factories/metrics.rb
+++ b/spec/factories/metrics.rb
@@ -98,14 +98,14 @@ FactoryGirl.define  do
     trait :metric_fu do
       languages [:RUBY]
       metric_collector_name "MetricFu"
-      scope :METHOD
+      scope 'METHOD'
     end
 
     factory :flog_metric, parent: :native_metric do
       metric_fu
 
       name "Pain"
-      code 'flog'
+      code :flog
     end
 
     factory :saikuro_metric,  parent: :native_metric do
@@ -119,7 +119,8 @@ FactoryGirl.define  do
       metric_fu
 
       name "Duplicate Code"
-      code 'flay'
+      code :flay
+      scope FactoryGirl.build(:software_granularity)
     end
 
 

--- a/spec/lib/metric_collector/base_spec.rb
+++ b/spec/lib/metric_collector/base_spec.rb
@@ -42,5 +42,34 @@ describe MetricCollector::Base, :type => :model do
         expect { MetricCollector::Base.available? }.to raise_error(NotImplementedError)
       end
     end
+
+    describe 'parse_supported_metrics' do
+      subject { MetricCollector::Base.new("", "", []) }
+      let(:metrics) { {metrics:
+                        {flog:
+                          {name: "Pain",
+                           description: "",
+                           scope: "METHOD",
+                           type: "NativeMetricSnapshot"},
+                         flay:
+                          {name: "Duplicate Code",
+                           description: "",
+                           scope: "PACKAGE",
+                           type: "HotspotMetricSnapshot"}
+                        }
+                      }
+                    }
+
+      before :each do
+        YAML.expects(:load_file).with("#{Rails.root}/lib/metric_collector/native/metric_fu/metrics.yml").returns(metrics)
+      end
+
+      it 'is expected to return a code => Metric hash' do
+        supported_metrics = { flog: FactoryGirl.build(:flog_metric, description: ''),
+                              flay: FactoryGirl.build(:flay_metric, description: '') }
+
+        expect(subject.parse_supported_metrics("#{Rails.root}/lib/metric_collector/native/metric_fu/metrics.yml", "MetricFu", [:RUBY])).to eq(supported_metrics)
+      end
+    end
   end
 end

--- a/spec/lib/metric_collector/native/metric_fu/collector_spec.rb
+++ b/spec/lib/metric_collector/native/metric_fu/collector_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'metric_collector'
 
 describe MetricCollector::Native::MetricFu::Collector, :type => :model do
-  subject{ MetricCollector::Native::MetricFu::Collector.new }
+  subject { MetricCollector::Native::MetricFu::Collector.new }
 
   describe 'collect_metrics' do
     let(:code_directory) { Dir.pwd }

--- a/spec/lib/metric_collector/native/metric_fu/collector_spec.rb
+++ b/spec/lib/metric_collector/native/metric_fu/collector_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 require 'metric_collector'
 
 describe MetricCollector::Native::MetricFu::Collector, :type => :model do
+  subject{ MetricCollector::Native::MetricFu::Collector.new }
 
   describe 'collect_metrics' do
     let(:code_directory) { Dir.pwd }
@@ -9,8 +10,6 @@ describe MetricCollector::Native::MetricFu::Collector, :type => :model do
     let(:path) { "" }
     let(:runner) { mock('metric_fu_runner') }
     let(:processing) { FactoryGirl.build(:processing) }
-
-    subject{ MetricCollector::Native::MetricFu::Collector.new }
 
     it 'is expected to run the collector and parse the results' do
       MetricCollector::Native::MetricFu::Runner.expects(:new).with(repository_path: code_directory).returns(runner)


### PR DESCRIPTION
There was duplicated code between MetricFu and Randon which has been
extracted to the superclass and can properly handle the new metric list
YAML field `type`.

Signed off by: Diego Araújo <diegoamc90@gmail.com>