### PR TITLE
Fix Analizo results ROOT mudule aggregation

### DIFF
--- a/features/runner.feature
+++ b/features/runner.feature
@@ -15,6 +15,7 @@ Feature: Runner run
     And I should have a READY processing for the given repository
     And the processing retrieved should have a Root ModuleResult
     And the Root ModuleResult retrieved should have a list of MetricResults
+    And at least one MetricResult should be non-zero
     And the Root ModuleResult retrieved should not have a MetricResult for the compound metric
 
   @clear_repository @kalibro_configuration_restart

--- a/features/step_definitions/runner_steps.rb
+++ b/features/step_definitions/runner_steps.rb
@@ -218,7 +218,14 @@ Then(/^the HotspotResults should have other related results indicating the dupli
   end
 end
 
-
 Then(/^the Root ModuleResult retrieved should have exactly "(.*?)" MetricResults$/) do |count|
   expect(@processing.root_module_result.metric_results.count).to eq(count.to_i)
+end
+
+Then(/^at least one MetricResult should be non\-zero$/) do
+  metric_results = @processing.root_module_result.metric_results
+
+  values = metric_results.map { |metric_result| metric_result.value }
+
+  expect(values.reduce(:+)).to_not eq(0)
 end

--- a/features/step_definitions/runner_steps.rb
+++ b/features/step_definitions/runner_steps.rb
@@ -225,7 +225,7 @@ end
 Then(/^at least one MetricResult should be non\-zero$/) do
   metric_results = @processing.root_module_result.metric_results
 
-  values = metric_results.map { |metric_result| metric_result.value }
+  values = metric_results.map { |metric_result| metric_result.value.abs }
 
   expect(values.reduce(:+)).to_not eq(0)
 end

--- a/lib/metric_collector/native/analizo/parser.rb
+++ b/lib/metric_collector/native/analizo/parser.rb
@@ -53,6 +53,7 @@ module MetricCollector
         def parse(result_map)
           if result_map['_filename'].nil?
             module_result = module_result("ROOT", KalibroClient::Entities::Miscellaneous::Granularity::SOFTWARE)
+            self.processing.update!(root_module_result: module_result)
           else
             module_result = module_result(module_name(result_map['_filename'].last, result_map['_module']), KalibroClient::Entities::Miscellaneous::Granularity::CLASS)
           end

--- a/lib/processor/metric_results_checker.rb
+++ b/lib/processor/metric_results_checker.rb
@@ -11,7 +11,8 @@ module Processor
         }
       end
 
-      context.processing.module_results.each do |module_result|
+      module_results = context.processing.module_results - [context.processing.root_module_result]
+      module_results.each do |module_result|
         metrics_check_list = wanted_metrics.clone
 
         module_result.metric_results.each do |metric_result|

--- a/spec/factories/module_results.rb
+++ b/spec/factories/module_results.rb
@@ -14,6 +14,10 @@ FactoryGirl.define do
       kalibro_module { FactoryGirl.build(:kalibro_module, granularity: FactoryGirl.build(:package_granularity)) }
     end
 
+    trait :software do
+      kalibro_module { FactoryGirl.build(:kalibro_module, granularity: FactoryGirl.build(:software_granularity)) }
+    end
+
     trait :with_id do
       id 14
     end

--- a/spec/lib/metric_collector/native/analizo/parser_spec.rb
+++ b/spec/lib/metric_collector/native/analizo/parser_spec.rb
@@ -25,6 +25,7 @@ describe MetricCollector::Native::Analizo::Parser, :type => :model do
         ModuleResult.expects(:find_by_module_and_processing).with(class_kalibro_module, processing).returns(module_result)
         root_kalibro_module.expects(:save)
         ModuleResult.expects(:create).with(kalibro_module: root_kalibro_module, processing: processing).returns(module_result)
+        processing.expects(:update!).with(root_module_result: module_result)
         TreeMetricResult.expects(:create).with(metric: metric_collector_details.supported_metrics["acc"], value: 0.0, module_result: module_result, metric_configuration_id: wanted_metric_configuration.id)
 
         subject.parse_all(analizo_metric_collector_list.raw_result)

--- a/spec/lib/processor/metric_results_checker_spec.rb
+++ b/spec/lib/processor/metric_results_checker_spec.rb
@@ -13,7 +13,8 @@ describe Processor::MetricResultsChecker do
       let(:metric_result) { FactoryGirl.build(:tree_metric_result,
                                                metric_configuration: saikuro_metric_configuration) }
       let(:module_result) { FactoryGirl.build(:module_result_class_granularity) }
-      let(:processing) { FactoryGirl.build(:processing, repository: repository, root_module_result: module_result, module_results: [module_result]) }
+      let(:root_module_result) { FactoryGirl.build(:module_result, :software, metric_results: []) }
+      let(:processing) { FactoryGirl.build(:processing, repository: repository, root_module_result: root_module_result, module_results: [root_module_result, module_result]) }
       let(:context) { FactoryGirl.build(:context, repository: repository, processing: processing) }
 
       context 'when there is a wanted metric that produced no results for the given module' do
@@ -30,6 +31,14 @@ describe Processor::MetricResultsChecker do
           TreeMetricResult.expects(:create).with(value: default_value, module_result: module_result, metric_configuration_id: flog_metric_configuration.id)
 
           Processor::MetricResultsChecker.task(context)
+        end
+
+        it 'is NOT expected to create TreeMetricResult for the root module result' do
+          TreeMetricResult.expects(:create).with(value: default_value, module_result: module_result, metric_configuration_id: flog_metric_configuration.id)
+
+          Processor::MetricResultsChecker.task(context)
+
+          expect(root_module_result.metric_results).to be_empty
         end
       end
 


### PR DESCRIPTION
MetricResultsChecker was expecting that there were no ROOT
TreeModuleResults. Analizo's parser might generate a ROOT
TreeModuleResult for SOFTWARE metrics.

We've fixed Analizo parser in order to update the Processing with the
create ROOT ModuleResult and then the MetricResultsChecker was
programmed to ignore the ROOT module.

Closes: https://github.com/mezuro/kalibro_processor/issues/150