### PR TITLE
Notify exceptions within ActiveJob

### DIFF
--- a/app/jobs/processing_job.rb
+++ b/app/jobs/processing_job.rb
@@ -13,6 +13,13 @@ class ProcessingJob < ActiveJob::Base
     ScheduledProcessingJob.set(wait: period.days).perform_later(@context.repository) if period > 0
   end
 
+  # As for Rails 4.2.4 with Ruby 2.2.3, the rescue order is bottom up
+  # So this general rescue should come first to be the last one handled
+  rescue_from(Exception) do |exception|
+    ExceptionNotifier.notify_exception(exception)
+    raise exception
+  end
+
   rescue_from(Errors::ProcessingCanceledError) do
     @context.processing.destroy
   end


### PR DESCRIPTION
ExceptionNotifier does not work within the context of ActiveJob. So
we need to explicitly call Exception notifier.

Signed off by: Eduardo Araújo <duduktamg@hotmail.com>

Closes https://github.com/mezuro/kalibro_processor/issues/127