### PR TITLE
Fix missing mock on MetricCollectors find spec

### DIFF
--- a/spec/controllers/metric_collectors_controller_spec.rb
+++ b/spec/controllers/metric_collectors_controller_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe MetricCollectorsController, :type => :controller do
     context 'with an available collector' do
       before :each do
         MetricCollector::Native.expects(:details).returns([metric_collector_details])
+        MetricCollector::KolektiAdapter.expects(:details).returns([])
 
         post :find, name: metric_collector_details.name, format: :json
       end
@@ -59,6 +60,8 @@ RSpec.describe MetricCollectorsController, :type => :controller do
 
       before :each do
         MetricCollector::Native.expects(:details).returns([metric_collector_details])
+        MetricCollector::KolektiAdapter.expects(:details).returns([])
+
         post :find, name: metric_collector_name, format: :json
       end
 


### PR DESCRIPTION
While integrating with Kolekti we forgot about adding this mock that led
to caching errors depending on run order (seed 39368).

Signed off by: Diego Araújo <diegoamc90@gmail.com>