### PR TITLE
Implement PHP metrics using Kolekti PHPMD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
   - pushd kalibro_configurations
   - bundle exec rails s -p 8083 -d
   - popd
-  - bundle exec rake cucumber
+  - bundle exec cucumber --tags ~@docker
 
 notifications:
   email:

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,8 @@ gem 'exception_notification', '~> 4.1.0'
 gem 'foreman', '~> 0.78.0'
 
 gem 'kolekti'
-gem 'kolekti_analizo', git: 'https://github.com/mezuro/kolekti_analizo', branch: 'stable'
+gem 'kolekti_analizo', github: 'mezuro/kolekti_analizo', branch: 'stable'
+gem 'kolekti_cc_phpmd', github: 'mezuro/kolekti_cc_phpmd', branch: 'stable'
 
 group :test do
   # Easier test writing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,18 @@
 GIT
-  remote: https://github.com/mezuro/kolekti_analizo
-  revision: cd7d0c2795b8c9e44ec5c4bb639c341d44dd201c
+  remote: git://github.com/mezuro/kolekti_analizo.git
+  revision: 8d4cdf8b6fba0abc443c7696c5305d12d91a3a5e
   branch: stable
   specs:
-    kolekti_analizo (0.0.3)
+    kolekti_analizo (0.0.4)
+      kolekti (~> 1.0.1)
+
+GIT
+  remote: git://github.com/mezuro/kolekti_cc_phpmd.git
+  revision: b4060236bd2144e7ddd1d71fdb529b23724f21ed
+  branch: stable
+  specs:
+    kolekti_cc_phpmd (0.0.2)
+      codeclimate (~> 0.23)
       kolekti (~> 1.0)
 
 GEM
@@ -87,9 +96,20 @@ GEM
     code_analyzer (0.4.5)
       sexp_processor
     code_metrics (0.1.3)
+    codeclimate (0.23.0)
+      activesupport (~> 4.2, >= 4.2.1)
+      codeclimate-yaml (~> 0.8.0)
+      highline (~> 1.7, >= 1.7.2)
+      posix-spawn (~> 0.3, >= 0.3.11)
+      pry (~> 0.10.1)
+      rainbow (~> 2.0, >= 2.0.0)
+      tty-spinner (~> 0.1.0)
     codeclimate-test-reporter (0.4.7)
       simplecov (>= 0.7.1, < 1.0.0)
-    coderay (1.1.0)
+    codeclimate-yaml (0.8.0)
+      activesupport
+      secure_string
+    coderay (1.1.1)
     colored (1.2)
     colorize (0.7.7)
     concord (0.1.5)
@@ -148,6 +168,7 @@ GEM
     git (1.2.9.1)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    highline (1.7.8)
     hirb (0.7.3)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
@@ -161,7 +182,7 @@ GEM
     kalibro_client (3.0.1)
       activesupport (>= 2.2.1)
       faraday_middleware (~> 0.9)
-    kolekti (1.0.0)
+    kolekti (1.0.1)
       kalibro_client (~> 3.0)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -179,6 +200,7 @@ GEM
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     metaclass (0.0.4)
+    method_source (0.8.2)
     metric_fu (4.12.0)
       cane (~> 2.5, >= 2.5.2)
       churn (~> 0.0.35)
@@ -212,7 +234,12 @@ GEM
     parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
     pg (0.18.2)
+    posix-spawn (0.3.11)
     procto (0.0.2)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     psych (2.0.15)
     rack (1.6.4)
     rack-test (0.6.3)
@@ -250,7 +277,7 @@ GEM
       activesupport (= 4.2.4)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (2.0.0)
+    rainbow (2.1.0)
     rake (10.4.2)
     rdoc (4.2.0)
     redcard (1.1.0)
@@ -289,6 +316,7 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    secure_string (1.3.3)
     sexp_processor (4.6.0)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
@@ -297,6 +325,7 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    slop (3.6.0)
     spring (1.3.6)
     sprockets (3.3.3)
       rack (~> 1.0)
@@ -313,6 +342,7 @@ GEM
       ref
     thor (0.19.1)
     thread_safe (0.3.5)
+    tty-spinner (0.1.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     unf (0.1.4)
@@ -354,6 +384,7 @@ DEPENDENCIES
   kalibro_client (~> 3.0)
   kolekti
   kolekti_analizo!
+  kolekti_cc_phpmd!
   metric_fu (~> 4.12.0)
   mocha
   pg

--- a/config/initializers/kolekti.rb
+++ b/config/initializers/kolekti.rb
@@ -1,4 +1,6 @@
 require 'kolekti'
 require 'kolekti_analizo'
+require 'kolekti/cc_phpmd'
 
 Kolekti.register_collector(Kolekti::Analizo::Collector)
+Kolekti.register_collector(Kolekti::CcPhpMd::Collector)

--- a/features/runner.feature
+++ b/features/runner.feature
@@ -106,3 +106,14 @@ Feature: Runner run
     And I should have a READY processing for the given repository
     And the processing retrieved should have a Root ModuleResult
     And the Root ModuleResult retrieved should have a list of MetricResults
+
+  @clear_repository @kalibro_configuration_restart @docker
+  Scenario: An existing php repository with a configuration with PHPMD (Hotspot Metrics)
+    Given I have a sample configuration with the PHPMD hotspot metric
+    And I have a sample php repository
+    And I have a processing within the sample repository
+    When I run for the given repository
+    Then the repository code_directory should exist
+    And I should have a READY processing for the given repository
+    And I should have some ModuleResults
+    And the ModuleResults should have HotspotResults for the ccvn metric

--- a/features/step_definitions/runner_steps.rb
+++ b/features/step_definitions/runner_steps.rb
@@ -19,7 +19,7 @@ end
 Given(/^I have a sample configuration with the (\w+) native metric$/) do |metric|
   metric_configuration_factory = (metric + "_metric_configuration").downcase
   metric_factory = (metric + "_metric").downcase
-  @configuration = FactoryGirl.create(:ruby_configuration, id: nil)
+  @configuration = FactoryGirl.create(:kalibro_configuration, id: nil)
   metric_configuration = FactoryGirl.create(metric_configuration_factory.to_sym,
                                             {id: 4,
                                              metric: FactoryGirl.build(metric_factory.to_sym),
@@ -39,7 +39,7 @@ end
 Given(/^I have a sample configuration with the (\w+) hotspot metric$/) do |metric|
   metric_configuration_factory = (metric + "_metric_configuration").downcase
   metric_factory = (metric + "_metric").downcase
-  @configuration = FactoryGirl.create(:ruby_configuration, id: nil)
+  @configuration = FactoryGirl.create(:kalibro_configuration, id: nil)
   metric = FactoryGirl.build(metric_factory.to_sym)
   @metric_configuration = FactoryGirl.create(metric_configuration_factory.to_sym,
                                              metric: metric,
@@ -58,10 +58,14 @@ Given(/^I have a sample ruby repository within the sample project$/) do
   @repository = FactoryGirl.create(:ruby_repository, :with_project_id, kalibro_configuration: @configuration)
 end
 
+Given(/^I have a sample php repository$/) do
+  @repository = FactoryGirl.create(:php_repository, :with_project_id, kalibro_configuration: @configuration)
+end
+
 Given(/^I have a sample configuration with the (\w+) python native metric$/) do |metric|
   metric_configuration_factory = (metric + "_metric_configuration").downcase
   metric_factory = (metric + "_metric").downcase
-  @configuration = FactoryGirl.create(:python_configuration, id: nil)
+  @configuration = FactoryGirl.create(:kalibro_configuration, id: nil)
   metric_configuration = FactoryGirl.create(metric_configuration_factory.to_sym,
                                             {id: 4,
                                              metric: FactoryGirl.build(metric_factory.to_sym),

--- a/spec/factories/kalibro_configurations.rb
+++ b/spec/factories/kalibro_configurations.rb
@@ -16,8 +16,8 @@
 
 FactoryGirl.define do
   factory :kalibro_configuration, class: KalibroClient::Entities::Configurations::KalibroConfiguration do
-    name "Java"
-    description "Code metrics for Java."
+    name "Test Kalibro Configuration"
+    description "Test Kalibro Configuration."
 
     trait :with_id do
       id 1
@@ -30,17 +30,5 @@ FactoryGirl.define do
     id 12
     name "Perl"
     description "Code metrics for Perl."
-  end
-
-  factory :ruby_configuration, class: KalibroClient::Entities::Configurations::KalibroConfiguration do
-    id 13
-    name "Ruby"
-    description "Code metrics for Ruby."
-  end
-
-  factory :python_configuration, class: KalibroClient::Entities::Configurations::KalibroConfiguration do
-    id 14
-    name "Python"
-    description "Code metrics for Python."
   end
 end

--- a/spec/factories/metric_configurations.rb
+++ b/spec/factories/metric_configurations.rb
@@ -82,6 +82,11 @@ FactoryGirl.define do
       metric { FactoryGirl.build(:logical_lines_of_code_metric) }
     end
 
+    trait :phpmd do
+      hotspot
+      metric { FactoryGirl.build(:phpmd_metric) }
+    end
+
     trait :flog_compound_metric_configuration do
       metric { FactoryGirl.build(:compound_flog_metric) }
       weight 1
@@ -101,6 +106,7 @@ FactoryGirl.define do
     factory :compound_metric_configuration, traits: [:compound_metric]
     factory :hotspot_metric_configuration, traits: [:hotspot_metric]
     factory :flog_metric_configuration, traits: [:flog]
+    factory :phpmd_metric_configuration, traits: [:phpmd]
     factory :flog_compound_metric_configuration, traits: [:flog_compound_metric_configuration]
     factory :saikuro_metric_configuration, traits: [:saikuro]
     factory :saikuro_compound_metric_configuration, traits: [:saikuro_compound_metric_configuration]

--- a/spec/factories/metrics.rb
+++ b/spec/factories/metrics.rb
@@ -170,5 +170,17 @@ FactoryGirl.define  do
       code 'lloc'
       scope { { "type" => :PACKAGE } }
     end
+
+    trait :phpmd do
+      languages [:PHP]
+      metric_collector_name "CodeClimate PHPMD"
+    end
+
+    factory :phpmd_metric, parent: :hotspot_metric do
+      phpmd
+
+      name "Controversial/CamelCaseVariableName"
+      code :ccvn
+    end
   end
 end

--- a/spec/factories/repositories.rb
+++ b/spec/factories/repositories.rb
@@ -31,6 +31,13 @@ FactoryGirl.define do
       description "Noosfero - a web-based social platform"
     end
 
+    trait :arquigrafia do
+      name "Arquigrafia"
+      scm_type "GIT"
+      address "https://github.com/anapaula/Arquigrafia-Laravel.git"
+      description "Arquigrafia"
+    end
+
     trait :ruby do
       kalibro_processor
     end
@@ -40,6 +47,10 @@ FactoryGirl.define do
       scm_type "GIT"
       address "https://github.com/mezuro/kalibro_client_py"
       description "Python version for KalibroClient"
+    end
+
+    trait :php do
+      arquigrafia
     end
 
     trait :another_branch do
@@ -53,6 +64,7 @@ FactoryGirl.define do
     factory :sbking_repository, traits: [:sbking]
     factory :ruby_repository, traits: [:ruby]
     factory :python_repository, traits: [:python]
+    factory :php_repository, traits: [:php]
     factory :custom_branch, traits: [:another_branch]
   end
 end


### PR DESCRIPTION
- Add the gem and update versions of other gems with necessary fixes.
- Create an acceptance test
- Add metric factories
- Add repository factories using the Arquigrafia-Laravel project
  (github.com/anapaula/Arquigrafia-Laravel)
- Remove usages of language-specific Kalibro Configurations in favour of
  a few shared ones, since their parameters don't actuall affect any
  processing
- Update Travis configuration to not run the CC-PHPMD tests, as they
  require Docker to bet set up. The tests of the gem itself should be
  sufficient, but in the future we might consider setting up Docker in
  Travis or moving to CircleCI.

Signed off by: Eduardo Araújo <duduktamg@hotmail.com>