### PR TITLE
Update kalibro_client and kolekti

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'rails-html-sanitizer', '~> 1.0'
 
 # Kalibro integration
-gem 'kalibro_client', '~> 3.0'
+gem 'kalibro_client', '~> 4.0'
 
 # YAML parser required for properly compactibility between mri and rbx
 gem 'psych', '~>2.0.12'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,14 +179,18 @@ GEM
       multi_json (~> 1.2)
     json (1.8.3)
     json_pure (1.8.2)
-    kalibro_client (3.0.1)
+    kalibro_client (4.0.0)
       activesupport (>= 2.2.1)
       faraday_middleware (~> 0.9)
-    kolekti (1.0.1)
-      kalibro_client (~> 3.0)
+      likeno (~> 1.1)
+    kolekti (1.0.2)
+      kalibro_client (~> 4.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     libv8 (3.16.14.11)
+    likeno (1.1.0)
+      activesupport (>= 2.2.1)
+      faraday_middleware
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -381,7 +385,7 @@ DEPENDENCIES
   foreman (~> 0.78.0)
   git (~> 1.2.7)
   jbuilder (~> 2.0)
-  kalibro_client (~> 3.0)
+  kalibro_client (~> 4.0)
   kolekti
   kolekti_analizo!
   kolekti_cc_phpmd!

--- a/app/controllers/metric_results_controller.rb
+++ b/app/controllers/metric_results_controller.rb
@@ -1,5 +1,5 @@
 class MetricResultsController < ApplicationController
-  rescue_from ActiveRecord::RecordNotFound, KalibroClient::Errors::RecordNotFound, with: :not_found
+  rescue_from ActiveRecord::RecordNotFound, Likeno::Errors::RecordNotFound, with: :not_found
   before_action :set_metric_result
 
   def repository_id

--- a/app/controllers/module_results_controller.rb
+++ b/app/controllers/module_results_controller.rb
@@ -1,5 +1,5 @@
 class ModuleResultsController < ApplicationController
-  rescue_from ActiveRecord::RecordNotFound, KalibroClient::Errors::RecordNotFound, with: :not_found
+  rescue_from ActiveRecord::RecordNotFound, Likeno::Errors::RecordNotFound, with: :not_found
   before_action :set_module_result, except: [:exists]
 
   def get

--- a/spec/jobs/processing_job_spec.rb
+++ b/spec/jobs/processing_job_spec.rb
@@ -92,7 +92,7 @@ describe ProcessingJob, :type => :job do
         end
 
         context 'with an unexpected error' do
-          let(:exception) { KalibroClient::Errors::RecordNotFound.new }
+          let(:exception) { Likeno::Errors::RecordNotFound.new }
           let(:no_method_error) { NoMethodError.new("NoMethodError") }
 
           it 'is expected to raise the error and notify' do


### PR DESCRIPTION
KalibroClient introduces a new error API based on Likeno.

This required an update on kolekti as it depends on kalibro_client it
required to be synced with the new version 4.

Improves https://github.com/mezuro/kalibro_processor/pull/183 with just the necessary gem updates.

Signed-off-by: Daniel Miranda <danielkza2@gmail.com>
Signed-off-by: Rafael Reggiani Manzo <rr.manzo@protonmail.com>
Signed-off-by: Eduardo Araújo <duduktamg@hotmail.com>