### PR TITLE
Hotspot codes error handling

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -5,6 +5,7 @@ KalibroProcessor is the processing web service for Mezuro.
 == Unreleased
 
 * Deprecates KalibroModule#module_results
+* Handle errors of compound metrics that use hotspot metric codes on their scripts
 
 == v1.2.1 - 01/04/2016
 

--- a/features/runner.feature
+++ b/features/runner.feature
@@ -117,3 +117,13 @@ Feature: Runner run
     And I should have a READY processing for the given repository
     And I should have some ModuleResults
     And the ModuleResults should have HotspotResults for the ccvn metric
+
+  @clear_repository @kalibro_configuration_restart
+  Scenario: Source code analysis when a compound metric uses a hotspot metric code
+    Given I have a sample configuration with the Flay hotspot metric
+    And I use the hotspot metric to create a compound metric
+    And I have a sample ruby repository
+    And I have a processing within the sample repository
+    When I run for the given repository
+    Then the analysis should terminate with an ERROR
+    And the error message should be "Cannot use hotspot metric codes to create compound metrics."

--- a/lib/compound_results/calculator.rb
+++ b/lib/compound_results/calculator.rb
@@ -12,7 +12,7 @@ module CompoundResults
       @module_result.tree_metric_results.each { |metric_result| evaluator.add_function(metric_result.metric_configuration.metric.code, "return #{metric_result.value};") }
 
       @module_result.hotspot_metric_results.each do |hotspot_metric_result|
-        evaluator.add_function(hotspot_metric_result.metric_configuration.metric.code, "throw Error('Cannot use hotspot metric codes to create compound metrics.')")
+        evaluator.add_function(hotspot_metric_result.metric_configuration.metric.code, "throw Error('Cannot use hotspot metric codes to create compound metrics.');")
       end
 
       @compound_metric_configurations.each do |compound_metric_configuration|

--- a/lib/compound_results/calculator.rb
+++ b/lib/compound_results/calculator.rb
@@ -11,6 +11,10 @@ module CompoundResults
       @module_result.reload # reloads to make sure that all the metric results are available
       @module_result.tree_metric_results.each { |metric_result| evaluator.add_function(metric_result.metric_configuration.metric.code, "return #{metric_result.value};") }
 
+      @module_result.hotspot_metric_results.each do |hotspot_metric_result|
+        evaluator.add_function(hotspot_metric_result.metric_configuration.metric.code, "throw Error('Cannot use hotspot metric codes to create compound metrics.')")
+      end
+
       @compound_metric_configurations.each do |compound_metric_configuration|
         evaluator.add_function(compound_metric_configuration.metric.code, compound_metric_configuration.metric.script)
       end

--- a/spec/lib/compound_results/calculator_spec.rb
+++ b/spec/lib/compound_results/calculator_spec.rb
@@ -36,7 +36,7 @@ describe CompoundResults::Calculator do
       before :each do
         CompoundResults::JavascriptEvaluator.any_instance.expects(:evaluate).with("#{compound_metric_configuration.metric.code}").raises(V8::Error.new("Cannot use hotspot metric codes to create compound metrics.", nil, nil))
         CompoundResults::JavascriptEvaluator.any_instance.expects(:add_function).with(compound_metric_configuration.metric.code, compound_metric_configuration.metric.script)
-        CompoundResults::JavascriptEvaluator.any_instance.expects(:add_function).with(hotspot_metric_configuration.metric.code, "throw Error('Cannot use hotspot metric codes to create compound metrics.')")
+        CompoundResults::JavascriptEvaluator.any_instance.expects(:add_function).with(hotspot_metric_configuration.metric.code, "throw Error('Cannot use hotspot metric codes to create compound metrics.');")
         hotspot_metric_result.expects(:metric_configuration).returns(hotspot_metric_configuration)
         module_result.expects(:hotspot_metric_results).returns([hotspot_metric_result])
         module_result.expects(:tree_metric_results).returns([])

--- a/spec/lib/compound_results/calculator_spec.rb
+++ b/spec/lib/compound_results/calculator_spec.rb
@@ -4,27 +4,48 @@ require 'compound_results'
 describe CompoundResults::Calculator do
   describe 'calculate' do
     let! (:module_result) { FactoryGirl.build(:module_result) }
-    let! (:metric_result) { FactoryGirl.build(:tree_metric_result) }
     let! (:compound_metric_configuration) { FactoryGirl.build(:compound_metric_configuration) }
-    let! (:metric_configuration) { FactoryGirl.build(:metric_configuration) }
-    let! (:value) { 13.0 }
 
-    before :each do
-      CompoundResults::JavascriptEvaluator.any_instance.expects(:add_function).with(metric_configuration.metric.code, "return #{metric_result.value};")
-      CompoundResults::JavascriptEvaluator.any_instance.expects(:add_function).with(compound_metric_configuration.metric.code, compound_metric_configuration.metric.script)
-      CompoundResults::JavascriptEvaluator.any_instance.expects(:evaluate).with("#{compound_metric_configuration.metric.code}").returns(value)
-      metric_result.expects(:metric_configuration).returns(metric_configuration)
-      module_result.expects(:tree_metric_results).returns([metric_result])
-      module_result.expects(:reload)
+    context 'compound metrics without hotspot metrics' do
+      let! (:metric_result) { FactoryGirl.build(:tree_metric_result) }
+      let! (:metric_configuration) { FactoryGirl.build(:metric_configuration) }
+      let! (:value) { 13.0 }
+
+      before :each do
+        CompoundResults::JavascriptEvaluator.any_instance.expects(:add_function).with(metric_configuration.metric.code, "return #{metric_result.value};")
+        CompoundResults::JavascriptEvaluator.any_instance.expects(:add_function).with(compound_metric_configuration.metric.code, compound_metric_configuration.metric.script)
+        module_result.expects(:hotspot_metric_results).returns([])
+        CompoundResults::JavascriptEvaluator.any_instance.expects(:evaluate).with("#{compound_metric_configuration.metric.code}").returns(value)
+        metric_result.expects(:metric_configuration).returns(metric_configuration)
+        module_result.expects(:tree_metric_results).returns([metric_result])
+        module_result.expects(:reload)
+      end
+
+      it 'is expected to create a new TreeMetricResult' do
+        TreeMetricResult.expects(:create).with(metric: compound_metric_configuration.metric,
+                                           module_result: module_result,
+                                           metric_configuration_id: compound_metric_configuration.id,
+                                           value: value)
+
+        CompoundResults::Calculator.new(module_result, [compound_metric_configuration]).calculate
+      end
     end
+    context 'compound metrics that use a hotspot metric code' do
+      let! (:hotspot_metric_configuration) { FactoryGirl.build(:hotspot_metric_configuration) }
+      let! (:hotspot_metric_result) { FactoryGirl.build(:hotspot_metric_result) }
+      before :each do
+        CompoundResults::JavascriptEvaluator.any_instance.expects(:evaluate).with("#{compound_metric_configuration.metric.code}").raises(V8::Error.new("Cannot use hotspot metric codes to create compound metrics.", nil, nil))
+        CompoundResults::JavascriptEvaluator.any_instance.expects(:add_function).with(compound_metric_configuration.metric.code, compound_metric_configuration.metric.script)
+        CompoundResults::JavascriptEvaluator.any_instance.expects(:add_function).with(hotspot_metric_configuration.metric.code, "throw Error('Cannot use hotspot metric codes to create compound metrics.')")
+        hotspot_metric_result.expects(:metric_configuration).returns(hotspot_metric_configuration)
+        module_result.expects(:hotspot_metric_results).returns([hotspot_metric_result])
+        module_result.expects(:tree_metric_results).returns([])
+        module_result.expects(:reload)
+      end
 
-    it 'is expected to create a new TreeMetricResult' do
-      TreeMetricResult.expects(:create).with(metric: compound_metric_configuration.metric,
-                                         module_result: module_result,
-                                         metric_configuration_id: compound_metric_configuration.id,
-                                         value: value)
-
-      CompoundResults::Calculator.new(module_result, [compound_metric_configuration]).calculate
+      it 'is expected to raise a V8 error' do
+        expect { CompoundResults::Calculator.new(module_result, [compound_metric_configuration]).calculate }.to raise_error(V8::Error, "Cannot use hotspot metric codes to create compound metrics.")
+      end
     end
   end
 end


### PR DESCRIPTION
Until now, we were not creating them. However, now we want to raise more meaningful errors to our users.

The error here is that we do not want to let the user create compound metric scripts that use hotspot metric codes. That is invalid because hotspot metric results should return messages and chunks of code, not values that can be used to calculate a compound metric.

The solution was to add a piece of code on the CompoundResultCalculator that creates functions signed by the code of the hotspot metric (just as we do with tree metrics) and define the body as a javscript that throws an error with a meaningful error message for this case.

Notice that the error will only be raised if there's actually a compound metric that uses a hotspot metric code on its script. Therefore, compound metrics that do not use hotspot metric codes should be fine. This solution makes the processing finish with an error state if there's a single broken compound metric.

This closes https://github.com/mezuro/kalibro_processor/issues/187.

The solution proposed here is different from the solution suggested on the issue above. Following the suggestion would probably create more errors. That is because we would have to parse all the compound metric scripts, guess if the tokens corresponded to codes and then check if those codes corresponded to hotspot metric codes. The suggested solution not only make the processing much slower, but also potentially creates more bugs due to parsing of scripts.