### PR TITLE
Deprecates KalibroModule#module_results

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -4,6 +4,8 @@ KalibroProcessor is the processing web service for Mezuro.
 
 == Unreleased
 
+* Deprecates KalibroModule#module_results
+
 == v1.2.1 - 01/04/2016
 
 * Update kalibro_client

--- a/app/models/kalibro_module.rb
+++ b/app/models/kalibro_module.rb
@@ -42,6 +42,12 @@ class KalibroModule < ActiveRecord::Base
     self.short_name
   end
 
+  def module_results
+    STDERR.puts 'DEPRECATED: use KalibroModule#module_result instead'
+    mr = self.module_result
+    mr.nil? ? [] : [mr]
+  end
+
   private
 
   def find_or_instantiate(name, granularity)

--- a/spec/models/kalibro_module_spec.rb
+++ b/spec/models/kalibro_module_spec.rb
@@ -117,5 +117,30 @@ describe KalibroModule, :type => :model do
         expect(subject.granularity).to be_a(KalibroClient::Entities::Miscellaneous::Granularity)
       end
     end
+
+    # This tests covers a deprecated method and should be removed in the future
+    describe 'module_results' do
+      context 'when there is a module result associated' do
+        let(:module_result) { FactoryGirl.build(:module_result) }
+
+        before :each do
+          subject.expects(:module_result).returns(module_result)
+        end
+
+        it 'is expected to return a list with the single module result associated with the kalibro module' do
+          expect(subject.module_results).to eq([module_result])
+        end
+      end
+
+      context 'when there is no module result associated' do
+        before :each do
+          subject.expects(:module_result).returns(nil)
+        end
+
+        it 'is expected to return an empty list' do
+          expect(subject.module_results).to eq([])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This is an ActiveRecord method that existed when a KalibroModule 'had
many' ModuleResults. Our business logic changed and now a KalibroModule
'belongs to' only one ModuleResult.

Our next major release should remove this deprecation.

Notice that when we remove that deprecation, we will need to change our [KalibroModule controller](https://github.com/mezuro/kalibro_processor/blob/master/app/controllers/kalibro_modules_controller.rb#L31) accordingly.