### PR TITLE
Update kolekti_radon

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -4,6 +4,8 @@ KalibroProcessor is the processing web service for Mezuro.
 
 == Unreleased
 
+* Fixes for ruby 2.0 and 2.1 compatibility
+
 == v1.3.1 - 11/05/2016
 
 * Fix ruby 2.0.0 support

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,10 +26,10 @@ GIT
 
 GIT
   remote: git://github.com/mezuro/kolekti_radon.git
-  revision: 79a30f1e4b3e29fabedfef02950c6d48c57e05d7
+  revision: 4b74c1c98e7a30c0cfae1575a9468956a70fdb8c
   branch: stable
   specs:
-    kolekti_radon (0.0.1)
+    kolekti_radon (0.0.2)
       kolekti
 
 GEM
@@ -238,7 +238,7 @@ GEM
     metric_fu-Saikuro (1.1.3)
     mime-types (2.99.1)
     mini_portile (0.6.2)
-    minitest (5.8.4)
+    minitest (5.9.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.12.0)
@@ -419,4 +419,4 @@ DEPENDENCIES
   unparser (< 0.2.5)
 
 BUNDLED WITH
-   1.11.2
+   1.12.4


### PR DESCRIPTION
The previous version was not compatible with Ruby versions 2.0 and 2.1 leading to the collector not getting listed as available on such cases.

This is similar to MetricFu issue (https://github.com/mezuro/kalibro_processor/pull/197) and should fix
the build https://travis-ci.org/mezuro/kalibro_processor/builds/131760706.