### PR TITLE
Test against older rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ rvm:
 addons:
   postgresql: "9.3"
 
+before_install:
+  - if ruby --version | cut -d ' ' -f 2 | grep -q 2.1.5p273 ; then gem update --system 2.4.8; fi
+
 before_script:
   # Set script configuration
   - export ANALIZO_VERSION='1.17.0' # Version >1.17.0 needs Ubuntu 13.10/Debian 7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
   - 2.3.0
+  - 2.0.0-p598 # CentOS 7
+  - 2.1.5 # Debian 8
 
 addons:
   postgresql: "9.3"

--- a/features/step_definitions/module_result_steps.rb
+++ b/features/step_definitions/module_result_steps.rb
@@ -14,7 +14,7 @@ When(/^I request the hotspot metric results for the "(.*?)" module result$/) do 
     @processing.root_module_result
   else
     @processing.module_results.joins(:kalibro_module).references(:kalibro_modules)
-      .where('kalibro_modules.long_name': module_name).first
+      .where('kalibro_modules.long_name' => module_name).first
   end
   expect(module_result).not_to be_nil, "expected module result with name '#{module_name}', not found"
 


### PR DESCRIPTION
This should prevent regression on Ruby compatibility.

Closes https://github.com/mezuro/kalibro_processor/issues/131