### PR TITLE
Update kolekti_metricfu

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -4,6 +4,8 @@ KalibroProcessor is the processing web service for Mezuro.
 
 == Unreleased
 
+* Update KolektiMetricfu
+
 == v1.3.2 - 25/05/2016
 
 * Fixes for ruby 2.0 and 2.1 compatibility

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,10 +17,11 @@ GIT
 
 GIT
   remote: git://github.com/mezuro/kolekti_metricfu.git
-  revision: 931e783f4b6c1d5295f2080006f62b31d7906699
+  revision: f04006f7d0308f84db5ab493fb70e2f29a461d1a
   branch: stable
   specs:
-    kolekti_metricfu (0.0.3)
+    kolekti_metricfu (0.0.4)
+      flog (~> 4.3.2)
       kolekti (~> 1.1)
       metric_fu (~> 4.12.0)
 
@@ -77,7 +78,7 @@ GEM
     addressable (2.4.0)
     arel (6.0.3)
     arrayfields (4.9.2)
-    ast (2.2.0)
+    ast (2.3.0)
     builder (3.2.2)
     byebug (6.0.2)
     cane (2.6.2)
@@ -170,8 +171,9 @@ GEM
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
     fattr (2.3.0)
-    flay (2.7.0)
+    flay (2.8.0)
       erubis (~> 2.7.0)
+      path_expander (~> 1.0)
       ruby_parser (~> 3.0)
       sexp_processor (~> 4.0)
     flog (4.3.2)
@@ -236,12 +238,12 @@ GEM
       reek (>= 1.3.4, < 3.0)
       roodi (~> 3.1)
     metric_fu-Saikuro (1.1.3)
-    mime-types (2.99.1)
+    mime-types (2.99.2)
     mini_portile (0.6.2)
     minitest (5.9.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    multi_json (1.12.0)
+    multi_json (1.12.1)
     multi_test (0.1.2)
     multipart-post (2.0.0)
     net-scp (1.2.1)
@@ -250,9 +252,10 @@ GEM
     netrc (0.11.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
-    parallel (1.8.0)
+    parallel (1.9.0)
     parser (2.2.3.0)
       ast (>= 1.1, < 3.0)
+    path_expander (1.0.0)
     pg (0.18.2)
     posix-spawn (0.3.11)
     procto (0.0.3)


### PR DESCRIPTION
This restricts the flog version getting installed as MetricFu
dependency. The latest is not actually compatible with MetricFu
interface.