### PR TITLE
Aggregation performance

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -4,6 +4,7 @@ KalibroProcessor is the processing web service for Mezuro.
 
 == Unreleased
 
+* Introduce performance tests for Aggregator
 * Update KolektiMetricfu
 
 == v1.3.2 - 25/05/2016

--- a/Gemfile
+++ b/Gemfile
@@ -91,6 +91,9 @@ group :development, :test do
   gem 'capistrano-rails'
   gem 'capistrano-bundler'
   gem 'capistrano-rvm', "~>0.1.0"
+
+  # Ruby profilling
+  gem 'ruby-prof'
 end
 
 # Acceptance tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,6 +332,7 @@ GEM
       rspec-mocks (~> 3.3.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
+    ruby-prof (0.15.9)
     ruby-progressbar (1.8.1)
     ruby_parser (3.8.2)
       sexp_processor (~> 4.1)
@@ -414,6 +415,7 @@ DEPENDENCIES
   rails (= 4.2.4)
   rails-html-sanitizer (~> 1.0)
   rspec-rails (~> 3.3.2)
+  ruby-prof
   sdoc (~> 0.4.0)
   shoulda-matchers (~> 2.8.0)
   simplecov

--- a/performance/base.rb
+++ b/performance/base.rb
@@ -1,0 +1,65 @@
+module Performance
+  class Base
+    def initialize
+      @results = {}
+    end
+
+    def setup; end
+    def teardown; end
+
+    def subject; raise NotImplementedError; end
+
+    def run
+      self.run_process_time
+      self.run_wall_time
+
+      self.print
+    end
+
+    protected
+
+    def run_wall_time
+      self.setup
+
+      RubyProf.measure_mode = RubyProf::WALL_TIME
+
+      @results['Wall Time'] = []
+      (1..5).each do |it|
+        @results['Wall Time'] << RubyProf.profile do
+          self.subject
+        end
+      end
+
+      self.teardown
+    end
+
+    def run_process_time
+      self.setup
+
+      RubyProf.measure_mode = RubyProf::PROCESS_TIME
+
+      @results['Process Time'] = []
+      (1..5).each do |it|
+        @results['Process Time'] << RubyProf.profile do
+          self.subject
+        end
+      end
+
+      self.teardown
+    end
+
+    def print
+      puts "\n"
+      puts "#{self.class.name}\n----------"
+
+      @results.each do |title, result|
+        total = 0.0
+
+        result.each { |r| r.threads.each { |thread| total += thread.total_time} }
+
+        puts "* #{title}: #{total/result.count}"
+      end
+      puts "\n"
+    end
+  end
+end

--- a/performance/base.rb
+++ b/performance/base.rb
@@ -1,11 +1,22 @@
+require 'database_cleaner'
+require 'kalibro_client/kalibro_cucumber_helpers'
+
 module Performance
   class Base
     def initialize
       @results = {}
     end
 
-    def setup; end
-    def teardown; end
+    def setup
+      DatabaseCleaner.strategy = :truncation
+      KalibroClient::KalibroCucumberHelpers.clean_configurations
+      DatabaseCleaner.clean
+    end
+
+    def teardown
+      KalibroClient::KalibroCucumberHelpers.clean_configurations
+      DatabaseCleaner.clean
+    end
 
     def subject; raise NotImplementedError; end
 

--- a/performance/performance.rb
+++ b/performance/performance.rb
@@ -1,0 +1,6 @@
+require 'ruby-prof'
+require_relative '../config/environment'
+
+require_relative 'base'
+
+module Performance; end

--- a/performance/performance.rb
+++ b/performance/performance.rb
@@ -1,3 +1,5 @@
+ENV["RAILS_ENV"] ||= "test"
+
 require 'ruby-prof'
 require_relative '../config/environment'
 

--- a/performance/tests/aggregation.rb
+++ b/performance/tests/aggregation.rb
@@ -1,0 +1,23 @@
+require_relative '../performance'
+require 'processor'
+
+module Performance
+  class Aggregation < Base
+    def setup
+      super
+
+      @kalibro_configuration = FactoryGirl.create(:kalibro_configuration)
+      @code_dir = "/tmp/test"
+      @repository = FactoryGirl.create(:repository, scm_type: "GIT", kalibro_configuration: @kalibro_configuration, code_directory: @code_dir)
+      @root_module_result = FactoryGirl.create(:module_result, id: nil, processing: nil)
+      @processing = FactoryGirl.create(:processing, repository: @repository, root_module_result: @root_module_result, id: nil)
+      @context = FactoryGirl.build(:context, repository: @repository, processing: @processing)
+    end
+
+    def subject
+      Processor::Aggregator.task(context)
+    end
+  end
+end
+
+Performance::Aggregation.new.run

--- a/performance/tests/aggregation.rb
+++ b/performance/tests/aggregation.rb
@@ -13,7 +13,7 @@ module Performance
       metric_configuration = FactoryGirl.build(:metric_configuration, metric: FactoryGirl.build(:maintainability_metric), id: nil, kalibro_configuration_id: kalibro_configuration.id)
       code_dir = "/tmp/test"
       repository = FactoryGirl.create(:repository, scm_type: "GIT", kalibro_configuration: kalibro_configuration, code_directory: code_dir)
-      root_module_result = FactoryGirl.create(:module_result, id: nil, processing: nil)
+      root_module_result = FactoryGirl.create(:module_result, id: nil, processing: nil, tree_metric_results: [], hotspot_metric_results: [])
       processing = FactoryGirl.create(:processing, repository: repository, root_module_result: root_module_result, id: nil)
       @context = FactoryGirl.build(:context, repository: repository, processing: processing)
 
@@ -23,7 +23,7 @@ module Performance
 
         previous_module_results.each do |parent|
           (0..(TREE_WIDTH - 1)).each do
-            next_module_results << FactoryGirl.create(:module_result, id: nil, processing: processing, parent: parent)
+            next_module_results << FactoryGirl.create(:module_result, id: nil, processing: processing, parent: parent, tree_metric_results: [], hotspot_metric_results: [])
           end
         end
 

--- a/performance/tests/aggregation.rb
+++ b/performance/tests/aggregation.rb
@@ -10,7 +10,16 @@ module Performance
       super
 
       kalibro_configuration = FactoryGirl.create(:kalibro_configuration)
-      metric_configuration = FactoryGirl.create(:metric_configuration, metric: FactoryGirl.build(:maintainability_metric), id: nil, kalibro_configuration_id: kalibro_configuration.id)
+      metric_configurations = [
+        FactoryGirl.create(:metric_configuration, metric: FactoryGirl.build(:maintainability_metric), id: nil, kalibro_configuration_id: kalibro_configuration.id),
+        FactoryGirl.create(:metric_configuration, metric: FactoryGirl.build(:acc_metric), id: nil, kalibro_configuration_id: kalibro_configuration.id),
+        FactoryGirl.create(:metric_configuration, metric: FactoryGirl.build(:flog_metric), id: nil, kalibro_configuration_id: kalibro_configuration.id),
+        FactoryGirl.create(:metric_configuration, metric: FactoryGirl.build(:loc_metric), id: nil, kalibro_configuration_id: kalibro_configuration.id),
+        FactoryGirl.create(:metric_configuration, metric: FactoryGirl.build(:saikuro_metric), id: nil, kalibro_configuration_id: kalibro_configuration.id),
+        FactoryGirl.create(:metric_configuration, metric: FactoryGirl.build(:logical_lines_of_code_metric), id: nil, kalibro_configuration_id: kalibro_configuration.id),
+        FactoryGirl.create(:metric_configuration, metric: FactoryGirl.build(:cyclomatic_metric), id: nil, kalibro_configuration_id: kalibro_configuration.id),
+        FactoryGirl.create(:metric_configuration, metric: FactoryGirl.build(:lines_of_code_metric, code: 'pyloc'), id: nil, kalibro_configuration_id: kalibro_configuration.id)
+      ]
       code_dir = "/tmp/test"
       repository = FactoryGirl.create(:repository, scm_type: "GIT", kalibro_configuration: kalibro_configuration, code_directory: code_dir)
       root_module_result = FactoryGirl.create(:module_result,
@@ -45,11 +54,13 @@ module Performance
       end
 
       previous_module_results.each do |module_result|
-        FactoryGirl.create(:tree_metric_result,
-                           module_result: module_result,
-                           metric_configuration: metric_configuration,
-                           metric: metric_configuration.metric,
-                           value: rand)
+        metric_configurations.each do |metric_configuration|
+          FactoryGirl.create(:tree_metric_result,
+                             module_result: module_result,
+                             metric_configuration: metric_configuration,
+                             metric: metric_configuration.metric,
+                             value: rand)
+        end
       end
 
       puts "Done creating #{ModuleResult.count} ModuleResults and #{MetricResult.count} MetricResults that will get aggregated following"

--- a/performance/tests/aggregation.rb
+++ b/performance/tests/aggregation.rb
@@ -3,19 +3,46 @@ require 'processor'
 
 module Performance
   class Aggregation < Base
+    TREE_HEIGHT = 10
+    TREE_WIDTH = 2
+
     def setup
       super
 
-      @kalibro_configuration = FactoryGirl.create(:kalibro_configuration)
-      @code_dir = "/tmp/test"
-      @repository = FactoryGirl.create(:repository, scm_type: "GIT", kalibro_configuration: @kalibro_configuration, code_directory: @code_dir)
-      @root_module_result = FactoryGirl.create(:module_result, id: nil, processing: nil)
-      @processing = FactoryGirl.create(:processing, repository: @repository, root_module_result: @root_module_result, id: nil)
-      @context = FactoryGirl.build(:context, repository: @repository, processing: @processing)
+      kalibro_configuration = FactoryGirl.create(:kalibro_configuration)
+      metric_configuration = FactoryGirl.build(:metric_configuration, metric: FactoryGirl.build(:maintainability_metric), id: nil, kalibro_configuration_id: kalibro_configuration.id)
+      code_dir = "/tmp/test"
+      repository = FactoryGirl.create(:repository, scm_type: "GIT", kalibro_configuration: kalibro_configuration, code_directory: code_dir)
+      root_module_result = FactoryGirl.create(:module_result, id: nil, processing: nil)
+      processing = FactoryGirl.create(:processing, repository: repository, root_module_result: root_module_result, id: nil)
+      @context = FactoryGirl.build(:context, repository: repository, processing: processing)
+
+      previous_module_results = [root_module_result]
+      (0..(TREE_HEIGHT - 2)).each do # The first level is the ROOT
+        next_module_results = []
+
+        previous_module_results.each do |parent|
+          (0..(TREE_WIDTH - 1)).each do
+            next_module_results << FactoryGirl.create(:module_result, id: nil, processing: processing, parent: parent)
+          end
+        end
+
+        previous_module_results = next_module_results
+      end
+
+      previous_module_results.each do |module_result|
+        FactoryGirl.create(:tree_metric_result,
+                           module_result: module_result,
+                           metric_configuration: metric_configuration,
+                           metric: metric_configuration.metric,
+                           value: rand)
+      end
+
+      puts "Done creating #{ModuleResult.count} ModuleResults and #{MetricResult.count} MetricResults that will get aggregated following"
     end
 
     def subject
-      Processor::Aggregator.task(context)
+      Processor::Aggregator.task(@context)
     end
   end
 end


### PR DESCRIPTION
Related to https://github.com/mezuro/kalibro_processor/issues/207 it adds some rudimentary profiling capabilities that can get extended accordingly to necessity.

For now it focus on `Aggregator` and its complexity that looks to be related to `MetricResult` lookup and thus the `KalibroConfiguration#metric_configurations` count.