### PR TITLE
Update aggregation performance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
+/prof
 
 # Backup files
 *~

--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,12 @@ gem 'kolekti_metricfu', github: 'mezuro/kolekti_metricfu', branch: 'stable'
 gem 'unparser', '< 0.2.5'
 gem 'kolekti_radon', github: 'mezuro/kolekti_radon', branch: 'stable'
 
+# Some statistics
+gem 'descriptive-statistics', '~> 2.1.2'
+
+# Bulk SQL inserts
+gem 'activerecord-import'
+
 group :test do
   # Easier test writing
   gem "shoulda-matchers", '~>2.8.0'
@@ -103,8 +109,7 @@ group :cucumber do
   # gem 'database_cleaner' # Removed because it is getting added above.
 end
 
-# Some statistics
-gem 'descriptive-statistics', '~> 2.1.2'
+
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       activemodel (= 4.2.4)
       activesupport (= 4.2.4)
       arel (~> 6.0)
+    activerecord-import (0.15.0)
+      activerecord (>= 3.2)
     activesupport (4.2.4)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -386,6 +388,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-import
   byebug
   capistrano (~> 3.4.0)
   capistrano-bundler
@@ -424,4 +427,4 @@ DEPENDENCIES
   unparser (< 0.2.5)
 
 BUNDLED WITH
-   1.12.4
+   1.12.5

--- a/performance/tests/aggregation.rb
+++ b/performance/tests/aggregation.rb
@@ -21,6 +21,7 @@ module Performance
         FactoryGirl.create(:metric_configuration, metric: FactoryGirl.build(:lines_of_code_metric, code: 'pyloc'), id: nil, kalibro_configuration_id: kalibro_configuration.id)
       ]
       code_dir = "/tmp/test"
+
       repository = FactoryGirl.create(:repository, scm_type: "GIT", kalibro_configuration: kalibro_configuration, code_directory: code_dir)
       root_module_result = FactoryGirl.create(:module_result,
                                               id: nil, processing: nil,
@@ -32,36 +33,33 @@ module Performance
       Processor::Preparer.metrics_list(@context)
 
       previous_module_results = [root_module_result]
-      (0..(TREE_HEIGHT - 2)).each do # The first level is the ROOT
-        next_module_results = []
+      ModuleResult.transaction do
+        (0..(TREE_HEIGHT - 2)).each do # The first level is the ROOT
+          next_module_results = []
 
-        previous_module_results.each do |parent|
-          (0..(TREE_WIDTH - 1)).each do
-            next_module_results << FactoryGirl.create(:module_result,
-                                                      id: nil,
-                                                      processing: processing,
-                                                      parent: parent,
-                                                      tree_metric_results: [],
-                                                      hotspot_metric_results: [])
-            FactoryGirl.create(:kalibro_module_with_package_granularity,
-                                module_result: next_module_results.last,
-                                long_name: [*('a'..'z'),*('0'..'9')].shuffle[0,8].join # random unique name
-                              )
+          previous_module_results.each do |parent|
+            (0..(TREE_WIDTH - 1)).each do
+              next_module_results << ModuleResult.create!(processing: processing,
+                                                          parent_id: parent.id)
+              FactoryGirl.create(:kalibro_module_with_package_granularity,
+                                  module_result: next_module_results.last,
+                                  long_name: [*('a'..'z'),*('0'..'9')].shuffle[0,8].join # random unique name
+                                )
+            end
           end
-        end
 
-        previous_module_results = next_module_results
+          previous_module_results = next_module_results
+        end
       end
 
+      tree_metric_results = []
       previous_module_results.each do |module_result|
         metric_configurations.each do |metric_configuration|
-          FactoryGirl.create(:tree_metric_result,
-                             module_result: module_result,
-                             metric_configuration: metric_configuration,
-                             metric: metric_configuration.metric,
-                             value: rand)
+          tree_metric_results << [module_result.id, metric_configuration.id, rand]
         end
       end
+
+      TreeMetricResult.import([:module_result_id, :metric_configuration_id, :value], tree_metric_results)
 
       puts "Done creating #{ModuleResult.count} ModuleResults and #{MetricResult.count} MetricResults that will get aggregated following"
     end


### PR DESCRIPTION
- Allow more customization in the test runner by setting the measure
mode and number of runs through the environment (using the
PROFILE_NUM_RUNS and RUBY_PROF_MEASURE_MODE vars - see the RubyProf
documentation for the latter).
- Save reports in ./prof/{test_name} by default
- Print current state during tests instead of all at the end. Makes it
easier to verify what's currently happening, such as whether we are on
setup, teardown, or which run
- Insert TreeMetricResults in bulk, using the activerecord-import gem