### PR TITLE
Acceptance tests fixes/improvements

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -4,6 +4,7 @@ KalibroProcessor is the processing web service for Mezuro.
 
 == Unreleased
 
+* Improve acceptance tests by fixing small bugs and adding processing times
 * Introduce performance tests for Aggregator
 * Update KolektiMetricfu
 

--- a/features/metric_result/module_result.feature
+++ b/features/metric_result/module_result.feature
@@ -5,12 +5,12 @@ Feature: ModuleResult retrieval
 
   @clear_repository @kalibro_configuration_restart
   Scenario: With a valid MetricResult id
-    Given I have a sample configuration with the Flay hotspot metric
+    Given I have sample readings
+    And I have a sample configuration with the Flay hotspot metric
     And I have the kalibro processor ruby repository with revision "v0.11.0"
     And I have a processing within the sample repository
     And I run for the given repository
-    And I have the root ModuleResult of the given processing
-    And I have the first MetricResult of the given ModuleResult
+    And I have a hotspot MetricResult descendant of the root ModuleResult
     When I request for the ModuleResult associated with the given MetricResult's id
     Then I should get the given ModuleResult json
 

--- a/features/step_definitions/module_result_steps.rb
+++ b/features/step_definitions/module_result_steps.rb
@@ -1,10 +1,7 @@
-Given(/^I have the root ModuleResult of the given processing$/) do
-  @processing.reload # The processing instance in memory might not be synced with the database modifications made by a previous processing
-  @module_result = @processing.root_module_result
-end
-
-Given(/^I have the first MetricResult of the given ModuleResult$/) do
-  @metric_result = @module_result.metric_results.first
+Given(/^I have a hotspot MetricResult descendant of the root ModuleResult$/) do
+  @processing.reload
+  @metric_result = @processing.root_module_result.descendant_hotspot_metric_results.first
+  @module_result = @metric_result.module_result
 end
 
 When(/^I request the hotspot metric results for the "(.*?)" module result$/) do |module_name|

--- a/features/step_definitions/runner_steps.rb
+++ b/features/step_definitions/runner_steps.rb
@@ -158,6 +158,13 @@ end
 
 When(/^I run for the given repository$/) do
   @repository.process(@processing)
+  @processing.reload
+
+  if @processing.state == 'READY'
+    @processing.process_times(true).each do |process_time|
+      puts '%-15s %.4fs' % [process_time.state + ':', process_time.time]
+    end
+  end
 end
 
 When(/^I wait for the "(.*?)" state$/) do |state|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -77,8 +77,6 @@ end
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
 Cucumber::Rails::Database.javascript_strategy = :truncation
 
-require "#{File.dirname(__FILE__)}/hooks"
-
 # Kalibro hooks
 require 'kalibro_client/kalibro_cucumber_helpers/hooks.rb'
 

--- a/spec/factories/kalibro_modules.rb
+++ b/spec/factories/kalibro_modules.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     name { ['home', 'user', 'project'] }
 
     trait :with_id do
-      id 51
+      sequence(:id, 1)
     end
 
     trait :with_granularity_software do

--- a/spec/factories/processings.rb
+++ b/spec/factories/processings.rb
@@ -3,7 +3,6 @@ FactoryGirl.define do
     created_at "2011-10-20T18:26:43.151+00:00"
     updated_at "2011-10-20T18:26:43.151+00:00"
     state "READY"
-    root_module_result_id 13
     module_results { [] }
 
     association :repository, factory: :repository, strategy: :build

--- a/spec/models/validators/kalibro_module_long_name_validator_spec.rb
+++ b/spec/models/validators/kalibro_module_long_name_validator_spec.rb
@@ -4,23 +4,18 @@ require 'validators/kalibro_module_long_name_validator'
 RSpec.describe KalibroModuleLongNameValidator, :type => :model do
   describe 'methods' do
     describe 'validate' do
-      subject { FactoryGirl.build(:kalibro_module) }
-      let!(:module_result) { FactoryGirl.build(:module_result, kalibro_module: same_name) }
-      let(:subject_module_result) { FactoryGirl.build(:module_result, processing: module_result.processing) }
-      let(:same_name) { FactoryGirl.build(:kalibro_module) }
-      let(:processing) { FactoryGirl.create(:processing) }
+      subject { FactoryGirl.build(:kalibro_module, module_result: module_result) }
+      let!(:existing_processing)     { FactoryGirl.create(:processing) }
+      let!(:existing_module_result)  { FactoryGirl.create(:module_result, kalibro_module: nil,
+                                                          processing: existing_processing) }
+      let!(:existing_kalibro_module) { FactoryGirl.create(:kalibro_module, module_result: existing_module_result) }
 
       context 'within the same processing' do
+        let!(:module_result) { FactoryGirl.create(:module_result, kalibro_module: nil,
+                                                  processing: existing_processing) }
+
         context 'and with the same granularity' do
           context 'and the same long name' do
-            before :each do
-              subject.module_result = subject_module_result
-              subject_module_result.kalibro_module = subject
-
-              same_name.save
-              module_result.save
-            end
-
             it 'is expected to add an error to the record' do
               subject.save
               expect(subject.errors).not_to be_empty
@@ -28,12 +23,8 @@ RSpec.describe KalibroModuleLongNameValidator, :type => :model do
           end
 
           context 'and a different long name' do
-            before :each do
-              subject.module_result = subject_module_result
-              subject_module_result.kalibro_module = subject
-            end
-
             it 'is expected to NOT add any errors' do
+              subject.long_name.reverse!
               subject.save
               expect(subject.errors).to be_empty
             end
@@ -44,16 +35,8 @@ RSpec.describe KalibroModuleLongNameValidator, :type => :model do
           let(:granularity) { FactoryGirl.build(:class_granularity) }
 
           context 'and the same long name' do
-            before :each do
-              subject.module_result = subject_module_result
-              subject_module_result.kalibro_module = subject
-              subject.granularity = granularity
-
-              same_name.save
-              module_result.save
-            end
-
             it 'is expected to NOT add any errors' do
+              subject.granularity = granularity
               subject.save
               expect(subject.errors).to be_empty
             end
@@ -62,19 +45,12 @@ RSpec.describe KalibroModuleLongNameValidator, :type => :model do
       end
 
       context 'within a different processing' do
-        let(:different_processing) { FactoryGirl.create(:processing) }
+        let!(:other_processing) { FactoryGirl.create(:processing) }
+        let!(:module_result)    { FactoryGirl.create(:module_result, kalibro_module: nil,
+                                                     processing: other_processing) }
 
         context 'and with the same granularity' do
           context 'and the same long name' do
-            before :each do
-              subject_module_result.processing = different_processing
-              subject.module_result = subject_module_result
-              subject_module_result.kalibro_module = subject
-
-              same_name.save
-              module_result.save
-            end
-
             it 'is expected to NOT add any errors' do
               subject.save
               expect(subject.errors).to be_empty


### PR DESCRIPTION
Some small fixes/improvements for issues/needs I ran into recently.

- Print processing times after processing steps so we don't lose sight of performance in the future
- Remove duplicate require of hooks.rb (it is already required automatically)
- Change the MetricResult ID test to not rely on the existence of a hotspot result on the root - we can only be sure that will happen for tree metrics after aggregation.