### PR TITLE
Fix PersistenceStrategy to wrap ModuleResult creation in transaction

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -4,6 +4,7 @@ KalibroProcessor is the processing web service for Mezuro.
 
 == Unreleased
 
+* Fix possible inconsistency in module result creation (lack of transaction)
 * Improve acceptance tests by fixing small bugs and adding processing times
 * Introduce performance tests for Aggregator
 * Update KolektiMetricfu


### PR DESCRIPTION
We don't want possible inconsistencies by allowing the KalibroModule to
become visible without it's corresponding ModuleResult.