### PR TITLE
Refactor performance tests

### DIFF
--- a/performance/performance.rb
+++ b/performance/performance.rb
@@ -4,5 +4,6 @@ require 'ruby-prof'
 require_relative '../config/environment'
 
 require_relative 'base'
+require_relative 'processing_step_test'
 
 module Performance; end

--- a/performance/processing_step_test.rb
+++ b/performance/processing_step_test.rb
@@ -1,0 +1,77 @@
+require_relative 'base'
+require 'processor'
+
+module Performance
+  class ProcessingStepTest < Base
+    attr_reader :repository, :processing, :kalibro_configuration, :metric_configurations, :context
+
+    def initialize
+      super
+
+      @kalibro_configuration = nil
+      @metric_configurations = []
+      @repository = nil
+      @processing = nil
+      @context = nil
+    end
+
+    def setup
+      super
+
+      @kalibro_configuration = FactoryGirl.create(:kalibro_configuration)
+      @metric_configurations = metrics.map do |metric|
+        FactoryGirl.create(:metric_configuration, metric: metric,
+                           kalibro_configuration_id: @kalibro_configuration.id)
+      end
+
+      @repository = FactoryGirl.create(:repository, kalibro_configuration: @kalibro_configuration)
+      @processing = FactoryGirl.create(:processing, repository: @repository)
+
+      @context = FactoryGirl.build(:context, repository: @repository, processing: @processing)
+      Processor::Preparer.metrics_list(@context)
+    end
+
+    protected
+
+    def metrics
+      @metrics ||= [
+        FactoryGirl.build(:maintainability_metric),
+        FactoryGirl.build(:acc_metric),
+        FactoryGirl.build(:flog_metric),
+        FactoryGirl.build(:loc_metric),
+        FactoryGirl.build(:saikuro_metric),
+        FactoryGirl.build(:logical_lines_of_code_metric),
+        FactoryGirl.build(:cyclomatic_metric),
+        FactoryGirl.build(:lines_of_code_metric, code: 'pyloc'),
+      ]
+    end
+
+    def setup_metric_results(tree_width, tree_height)
+      module_results_tree = FactoryGirl.create(:module_results_tree, processing: @processing,
+                                               width: tree_width, height: tree_height)
+      @processing.update!(root_module_result: module_results_tree.root)
+
+      FactoryGirl.create(:kalibro_module_with_package_granularity, module_result: module_results_tree.root,
+                         long_name: "ROOT")
+
+      kalibro_modules = module_results_tree.all.map do |module_result|
+        FactoryGirl.build(:kalibro_module_with_package_granularity, module_result: module_result,
+                          long_name: random_name)
+      end
+      KalibroModule.import!(kalibro_modules, batch_size: 100)
+
+      tree_metric_results = module_results_tree.levels.last.flat_map do |module_result|
+        @metric_configurations.map do |metric_configuration|
+          module_result.tree_metric_results.build(metric_configuration_id: metric_configuration.id, value: rand)
+        end
+      end
+      TreeMetricResult.import!(tree_metric_results, batch_size: 100)
+
+      puts "Created #{ModuleResult.count} ModuleResults and #{MetricResult.count} MetricResults"
+    end
+
+    def random_name
+      [*('a'..'z'),*('0'..'9')].shuffle[0,8].join
+    end
+  end
+end

--- a/performance/tests/aggregation.rb
+++ b/performance/tests/aggregation.rb
@@ -2,61 +2,15 @@ require_relative '../performance'
 require 'processor'
 
 module Performance
-  class Aggregation < Base
-    TREE_HEIGHT = 10
-    TREE_WIDTH = 2
-
-    METRICS = [
-      FactoryGirl.build(:maintainability_metric),
-      FactoryGirl.build(:acc_metric),
-      FactoryGirl.build(:flog_metric),
-      FactoryGirl.build(:loc_metric),
-      FactoryGirl.build(:saikuro_metric),
-      FactoryGirl.build(:logical_lines_of_code_metric),
-      FactoryGirl.build(:cyclomatic_metric),
-      FactoryGirl.build(:lines_of_code_metric, code: 'pyloc'),
-    ]
-
+  class Aggregation < ProcessingStepTest
     def setup
       super
 
-      kalibro_configuration = FactoryGirl.create(:kalibro_configuration)
-      metric_configurations = METRICS.map do |metric|
-        FactoryGirl.create(:metric_configuration, metric: metric,
-                           kalibro_configuration_id: kalibro_configuration.id)
-      end
-
-      repository = FactoryGirl.create(:repository, kalibro_configuration: kalibro_configuration)
-      processing = FactoryGirl.create(:processing, repository: repository)
-      module_results_tree = FactoryGirl.create(:module_results_tree, processing: processing,
-                                               width: TREE_WIDTH, height: TREE_HEIGHT)
-      processing.update!(root_module_result: module_results_tree.root)
-
-      FactoryGirl.create(:kalibro_module_with_package_granularity, module_result: module_results_tree.root,
-                         long_name: "ROOT")
-
-      @context = FactoryGirl.build(:context, repository: repository, processing: processing)
-      Processor::Preparer.metrics_list(@context)
-
-      kalibro_modules = module_results_tree.all.map do |module_result|
-        FactoryGirl.build(:kalibro_module_with_package_granularity, module_result: module_result,
-                          long_name: random_name)
-      end
-      KalibroModule.import!(kalibro_modules)
-
-      tree_metric_results = module_results_tree.levels.last.flat_map do |module_result|
-        metric_configurations.map do |metric_configuration|
-          TreeMetricResult.new(metric_configuration_id: metric_configuration.id, module_result: module_result,
-                               value: rand)
-        end
-      end
-      TreeMetricResult.import!(tree_metric_results)
-
-      puts "Done creating #{ModuleResult.count} ModuleResults and #{MetricResult.count} MetricResults that will get aggregated following"
+      setup_metric_results(2, 10)
     end
 
     def subject
-      Processor::Aggregator.task(@context)
+      Processor::Aggregator.task(context)
     end
 
     def teardown
@@ -65,11 +19,9 @@ module Performance
     end
 
     protected
-
-    def random_name
-      [*('a'..'z'),*('0'..'9')].shuffle[0,8].join
-    end
   end
 end
 
-Performance::Aggregation.new.run
+if __FILE__ == $0
+  Performance::Aggregation.new.run
+end

--- a/spec/factories/module_results.rb
+++ b/spec/factories/module_results.rb
@@ -20,16 +20,73 @@ FactoryGirl.define do
     end
 
     trait :with_id do
-      id 14
+      sequence(:id, 1)
     end
 
     trait :kalibro_module_with_id do
       kalibro_module { FactoryGirl.build(:kalibro_module_with_id) }
     end
 
+    trait :without_results do
+      tree_metric_results []
+      hotspot_metric_results []
+    end
+
     factory :module_result_class_granularity, traits: [:class]
     factory :module_result_with_id, traits: [:with_id]
     factory :module_result_with_kalibro_module_with_id, traits: [:kalibro_module_with_id]
     initialize_with { ModuleResult.new({parent: parent, kalibro_module: kalibro_module}) }
+  end
+
+  # This factory is used to DRY the logic for creating MetricResult trees, so all methods that need them can become
+  # simpler.
+  # Input/output attributes:
+  # - height:     the height the produced tree shall have. The root is included, so the minimum height is 1.
+  # - width:      how many child nodes each non-leaf node should have. The total number of nodes will be (2 ** height) - 1
+  # - with_ids:   whether to assign IDs to all the nodes. Only set it for test data that won't be saved to the DB.
+  # - processing: the processing to set to all the nodes
+  # - root:       the root node of the tree
+  # Output attributes:
+  # - all:        a list of all nodes in the three
+  # - levels:     a list of lists of a breadth-firt search. The first list will contain only the root, the second the
+  #               root's children, the third the root's grandchildren, and so forth.
+  factory :module_results_tree, class: OpenStruct do
+    height 3
+    width 2
+    with_ids false
+
+    trait :with_id do
+      with_ids true
+    end
+
+    transient do
+      processing { build(:processing, root_module_result: root) }
+    end
+
+    root { build(:module_result, :without_results, *(with_ids ? [:with_id] : []), parent: nil) }
+
+    after(:build) do |tree, evaluator|
+      tree.root.processing = evaluator.processing
+
+      parents = [tree.root]
+      tree.all = [tree.root]
+      tree.levels = [[tree.root]]
+
+      (evaluator.height - 1).times.each do |_|
+        parents = parents.flat_map do |parent|
+          # Ensure AR won't look into the database for children - we're faking IDs, it makes no sense to query for them
+          parent.association(:children).loaded! if evaluator.with_ids
+
+          evaluator.width.times.map do |_|
+            parent.children.build(attributes_for(:module_result, :without_results,
+                                                 *(evaluator.with_ids ? [:with_id] : []),
+                                                 parent: parent, processing: parent.processing))
+          end
+        end
+
+        tree.all += parents
+        tree.levels << parents
+      end
+    end
   end
 end


### PR DESCRIPTION
Split up common code for setup to make it easier to create other tests for processing steps.