### PR TITLE
Optimize TreeMetricResult#descendant_values

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -4,6 +4,7 @@ KalibroProcessor is the processing web service for Mezuro.
 
 == Unreleased
 
+* Transform TreeMetricResult#descendant_values into a single query for performance
 * Fix possible inconsistency in module result creation (lack of transaction)
 * Improve acceptance tests by fixing small bugs and adding processing times
 * Introduce performance tests for Aggregator

--- a/app/models/module_result.rb
+++ b/app/models/module_result.rb
@@ -16,12 +16,6 @@ class ModuleResult < ActiveRecord::Base
       where("kalibro_modules.granularity" => kalibro_module.granularity.to_s).first
   end
 
-  def tree_metric_result_for(metric)
-    self.reload # reloads to get recently created TreeMetricResults
-    self.tree_metric_results.each {|metric_result| return metric_result if metric_result.metric == metric}
-    return nil
-  end
-
   # Adding kalibro_module to the result
   def to_json(options={})
     json = super(options)

--- a/app/models/tree_metric_result.rb
+++ b/app/models/tree_metric_result.rb
@@ -14,10 +14,10 @@ class TreeMetricResult < MetricResult
   def grade; self.range.grade; end
 
   def descendant_values
-    module_result.children.map { |child|
-      metric_result = child.tree_metric_result_for(self.metric)
-      metric_result.value if metric_result
-    }.compact
+    self.class.
+      joins(:module_result).
+      where('module_results.parent_id' => module_result_id).
+      pluck(:value)
   end
 
   def as_json(options={})

--- a/spec/controllers/tree_metric_results_controller_spec.rb
+++ b/spec/controllers/tree_metric_results_controller_spec.rb
@@ -9,10 +9,8 @@ describe TreeMetricResultsController do
       let!(:module_result) { FactoryGirl.build(:module_result) }
 
       before :each do
-        module_result.expects(:tree_metric_result_for).with(metric_result.metric).returns(metric_result)
-        module_result.expects(:children).returns([module_result])
-        metric_result.expects(:module_result).returns(module_result)
-        TreeMetricResult.expects(:find).with(metric_result.id).returns(metric_result)
+        MetricResult.expects(:find).with(metric_result.id).returns(metric_result)
+        metric_result.expects(:descendant_values).returns([metric_result.value])
       end
 
       context 'json format' do

--- a/spec/models/module_result_spec.rb
+++ b/spec/models/module_result_spec.rb
@@ -65,30 +65,6 @@ describe ModuleResult, :type => :model do
   end
 
   describe 'method' do
-    describe 'tree_metric_result_for' do
-      subject { FactoryGirl.build(:module_result) }
-
-      let(:metric_result) {subject.tree_metric_results.first}
-
-      before :each do
-        subject.expects(:reload)
-      end
-
-      context 'when a module result has the specific metric' do
-        let(:metric) { subject.tree_metric_results.first.metric }
-        it 'should return the metric_result' do
-          expect(subject.tree_metric_result_for(metric)).to eq(metric_result)
-        end
-      end
-
-      context 'when a module result has not the specific metric' do
-        let(:another_metric) { FactoryGirl.build(:acc_metric) }
-        it 'should return the metric_result' do
-          expect(subject.tree_metric_result_for(another_metric)).to be_nil
-        end
-      end
-    end
-
     describe 'find_by_module_and_processing' do
       let!(:kalibro_module) { FactoryGirl.build(:kalibro_module) }
       let!(:processing) { FactoryGirl.build(:processing) }

--- a/spec/models/tree_metric_result_spec.rb
+++ b/spec/models/tree_metric_result_spec.rb
@@ -100,22 +100,16 @@ describe TreeMetricResult, :type => :model do
 
     describe 'descendant_values' do
       subject { FactoryGirl.build(:tree_metric_result) }
-      let(:son) { FactoryGirl.build(:tree_metric_result_with_value) }
-      let!(:module_result) { FactoryGirl.build(:module_result) }
 
       before :each do
-        subject.expects(:module_result).returns(module_result)
-        module_result.expects(:children).returns([module_result, module_result])
-        module_result.expects(:tree_metric_result_for).at_least_once.
-          with(subject.metric).returns(son)
+        query = mock()
+        described_class.expects(:joins).with(:module_result).returns(query)
+        query.expects(:where).with('module_results.parent_id' => subject.module_result_id).returns(query)
+        query.expects(:pluck).with(:value).returns([2.0, 2.0])
       end
 
       it "should return an array with all its children's values" do
         expect(subject.descendant_values).to eq([2.0, 2.0])
-      end
-
-      it "should be a float values array" do
-        expect(subject.descendant_values).to be_a(Array)
       end
     end
   end


### PR DESCRIPTION
The previous implementation was incredibly sub-optimal. It can be easily
replaced with a join on the parent_id.

Aggregation performance test results below:

Metric Count | Branch |  Wall Time (s) | Process Time (s)
-----------------------|-------------|-------------------------|------------------------------
1 | v1.3.2 | 34.16732797622681 | 29.564079139199997
1 | improve_descendant_values | 23.588372707366943 | 21.618301714000005
2 | v1.3.2 | 71.57923197746277 | 63.06931912939999
2 | improve_descendant_values | 47.487600564956665 | 46.2433640588
4 | v1.3.2 | 154.1164906024933 | 147.8050995992
4 | improve_descendant_values | 97.7507544517517 | 70.0752864698
8 | v1.3.2 | 333.3348692417145 | 311.43665788299995
8 | improve_descendant_values | 190.28073539733887 | 226.78861793199994

@mezuro/core we need a third pair of eyes here as well.

This is part of https://github.com/mezuro/kalibro_processor/issues/207.